### PR TITLE
fix: align client and schemas with PCO API v0 response format

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -111,7 +111,7 @@ function createClient() {
       'User-Agent': 'nz-legislation-tool/1.0.0',
     },
     searchParams: {
-      apikey: config.apiKey,
+      api_key: config.apiKey,
     },
     retry: {
       limit: 3,
@@ -171,13 +171,13 @@ export async function searchWorks(params: {
   try {
     const data = await client.get('v0/works', {
       searchParams: {
-        ...(params.query && { q: params.query }),
-        ...(params.type && { type: params.type }),
-        ...(params.status && { status: params.status }),
+        ...(params.query && { search_term: params.query }),
+        ...(params.type && { legislation_type: params.type === 'regulation' ? 'secondary_legislation' : params.type }),
+        ...(params.status && { legislation_status: params.status.replace(/-/g, '_') }),
         ...(params.from && { from: params.from }),
         ...(params.to && { to: params.to }),
-        ...(params.limit && { limit: params.limit.toString() }),
-        ...(params.offset && { offset: params.offset.toString() }),
+        ...(params.limit && { per_page: params.limit.toString() }),
+        ...(params.offset && { page: (Math.floor((params.offset || 0) / (params.limit || 20)) + 1).toString() }),
       },
     }).json();
 
@@ -238,8 +238,9 @@ export async function getWorkVersions(workId: string): Promise<Version[]> {
   const client = createClient();
 
   try {
-    const data = await client.get(`v0/works/${workId}/versions`).json();
-    return z.array(VersionSchema).parse(data);
+    const data = await client.get(`v0/works/${workId}/versions`).json() as { results?: unknown[] };
+    const results = Array.isArray(data) ? data : (data.results || []);
+    return z.array(VersionSchema).parse(results);
   } catch (error) {
     if (error instanceof NetworkError) {
       throw error;

--- a/src/models/index.ts
+++ b/src/models/index.ts
@@ -1,15 +1,18 @@
 /**
- * Data models for NZ Legislation API
+ * Data models for NZ Legislation API (PCO API v0)
  * Using Zod for runtime validation and type inference
+ *
+ * These schemas match the actual response format from
+ * https://api.legislation.govt.nz/v0/
  */
 
 import { z } from 'zod';
 
-// Work type enumeration
+// Work type enumeration — maps API values to CLI display values
 export const WorkTypeSchema = z.enum(['act', 'bill', 'regulation', 'instrument']);
 export type WorkType = z.infer<typeof WorkTypeSchema>;
 
-// Legislation status enumeration
+// Legislation status enumeration — maps API values to CLI display values
 export const LegislationStatusSchema = z.enum([
   'in-force',
   'not-yet-in-force',
@@ -23,32 +26,135 @@ export type LegislationStatus = z.infer<typeof LegislationStatusSchema>;
 const DateStringSchema = z.string().regex(/^\d{4}-\d{2}-\d{2}$/, 'Invalid date format (expected YYYY-MM-DD)');
 
 /**
- * Legislation Work model
+ * Format entry as returned by the API
+ */
+const ApiFormatSchema = z.object({
+  type: z.string(),
+  url: z.string(),
+});
+
+/**
+ * Latest matching version as returned in search results
+ */
+const LatestMatchingVersionSchema = z.object({
+  title: z.string(),
+  version_id: z.string(),
+  is_latest_version: z.boolean().optional(),
+  formats: z.array(ApiFormatSchema).optional(),
+});
+
+/**
+ * Map API legislation_type to WorkType
+ */
+function mapLegislationType(apiType: string): WorkType {
+  switch (apiType) {
+    case 'act': return 'act';
+    case 'bill': return 'bill';
+    case 'secondary_legislation': return 'regulation';
+    default: return 'instrument';
+  }
+}
+
+/**
+ * Map API legislation_status / act_status / bill_status to LegislationStatus
+ */
+function mapLegislationStatus(status: string | null | undefined): LegislationStatus {
+  if (!status) return 'not-yet-in-force';
+  switch (status) {
+    case 'in_force': return 'in-force';
+    case 'not_in_force': return 'repealed';
+    case 'repealed': return 'repealed';
+    case 'current': return 'not-yet-in-force'; // Bills in progress
+    case 'terminated': return 'withdrawn';
+    case 'revoked': return 'repealed';
+    default: return 'not-yet-in-force';
+  }
+}
+
+/**
+ * Raw API search result item — loose schema to accept the actual API shape
+ */
+const ApiWorkSchema = z.object({
+  work_id: z.string(),
+  legislation_type: z.string(),
+  legislation_status: z.string().nullable().optional(),
+  publisher: z.string().nullable().optional(),
+  administering_agencies: z.array(z.string()).optional(),
+  latest_matching_version: LatestMatchingVersionSchema,
+  // Act-specific fields
+  act_type: z.string().optional(),
+  act_status: z.string().optional(),
+  act_classification: z.string().optional(),
+  // Bill-specific fields
+  bill_type: z.string().optional(),
+  bill_status: z.string().optional(),
+  // Instrument-specific fields
+  instrument_type_group: z.string().optional(),
+  instrument_status: z.string().optional(),
+  instrument_classification: z.string().optional(),
+}).passthrough();
+
+/**
+ * Legislation Work model — normalized from API response
  * Represents an Act, Bill, Regulation, or other legislative instrument
  */
-export const WorkSchema = z.object({
-  id: z.string(),
-  title: z.string(),
-  shortTitle: z.string().optional(),
-  type: WorkTypeSchema,
-  status: LegislationStatusSchema,
-  date: DateStringSchema,
-  url: z.string().url(),
-  versionCount: z.number().default(0),
+export const WorkSchema = ApiWorkSchema.transform((raw) => {
+  const version = raw.latest_matching_version;
+  const htmlFormat = version.formats?.find(f => f.type === 'html');
+  const status = raw.legislation_status || raw.act_status || raw.bill_status || raw.instrument_status;
+
+  // Extract date from version_id (last segment is typically YYYY-MM-DD)
+  const versionParts = version.version_id.split('_');
+  const dateCandidate = versionParts[versionParts.length - 1];
+  const date = /^\d{4}-\d{2}-\d{2}$/.test(dateCandidate) ? dateCandidate : '1900-01-01';
+
+  return {
+    id: raw.work_id,
+    title: version.title,
+    shortTitle: undefined as string | undefined,
+    type: mapLegislationType(raw.legislation_type),
+    status: mapLegislationStatus(status),
+    date,
+    url: htmlFormat?.url || `https://www.legislation.govt.nz/${raw.work_id.replace(/_/g, '/')}/`,
+    versionCount: 0,
+  };
 });
 export type Work = z.infer<typeof WorkSchema>;
 
 /**
- * Version model
+ * Raw API version item
+ */
+const ApiVersionSchema = z.object({
+  version_id: z.string(),
+  work_id: z.string(),
+  title: z.string(),
+  is_latest_version: z.boolean().optional(),
+  legislation_type: z.string().optional(),
+  legislation_status: z.string().nullable().optional(),
+  act_status: z.string().optional(),
+  act_type: z.string().optional(),
+  formats: z.array(ApiFormatSchema).optional(),
+  administering_agencies: z.array(z.string()).optional(),
+}).passthrough();
+
+/**
+ * Version model — normalized from API response
  * Represents a specific version of a work
  */
-export const VersionSchema = z.object({
-  id: z.string(),
-  version: z.number(),
-  date: DateStringSchema,
-  isCurrent: z.boolean().default(false),
-  type: z.string(),
-  formats: z.array(z.string()),
+export const VersionSchema = ApiVersionSchema.transform((raw) => {
+  // Extract date from version_id
+  const versionParts = raw.version_id.split('_');
+  const dateCandidate = versionParts[versionParts.length - 1];
+  const date = /^\d{4}-\d{2}-\d{2}$/.test(dateCandidate) ? dateCandidate : '1900-01-01';
+
+  return {
+    id: raw.version_id,
+    version: 1, // API doesn't provide a numeric version
+    date,
+    isCurrent: raw.is_latest_version || false,
+    type: raw.legislation_type || raw.act_type || 'unknown',
+    formats: (raw.formats || []).map(f => f.url),
+  };
 });
 export type Version = z.infer<typeof VersionSchema>;
 
@@ -63,17 +169,23 @@ export const FormatInfoSchema = z.object({
 export type FormatInfo = z.infer<typeof FormatInfoSchema>;
 
 /**
- * Legislation Version with full content
+ * Legislation Version with full content — normalized from API response
  */
-export const LegislationVersionSchema = z.object({
-  id: z.string(),
-  workId: z.string(),
-  title: z.string(),
-  version: z.number(),
-  date: DateStringSchema,
-  isCurrent: z.boolean().default(false),
-  content: z.string().optional(),
-  formats: z.array(FormatInfoSchema),
+export const LegislationVersionSchema = ApiVersionSchema.transform((raw) => {
+  const versionParts = raw.version_id.split('_');
+  const dateCandidate = versionParts[versionParts.length - 1];
+  const date = /^\d{4}-\d{2}-\d{2}$/.test(dateCandidate) ? dateCandidate : '1900-01-01';
+
+  return {
+    id: raw.version_id,
+    workId: raw.work_id,
+    title: raw.title,
+    version: 1,
+    date,
+    isCurrent: raw.is_latest_version || false,
+    content: undefined as string | undefined,
+    formats: (raw.formats || []).map(f => ({ format: f.type, url: f.url })),
+  };
 });
 export type LegislationVersion = z.infer<typeof LegislationVersionSchema>;
 
@@ -87,15 +199,20 @@ export const PaginationLinksSchema = z.object({
 export type PaginationLinks = z.infer<typeof PaginationLinksSchema>;
 
 /**
- * Search results from API
+ * Search results from API — handles the actual PCO API v0 pagination format
  */
 export const SearchResultsSchema = z.object({
   total: z.number(),
-  offset: z.number().default(0),
-  limit: z.number().default(25),
+  page: z.number().optional(),
+  per_page: z.number().optional(),
   results: z.array(WorkSchema),
-  links: PaginationLinksSchema.optional(),
-});
+}).transform((raw) => ({
+  total: raw.total,
+  offset: ((raw.page || 1) - 1) * (raw.per_page || 20),
+  limit: raw.per_page || 20,
+  results: raw.results,
+  links: undefined as PaginationLinks | undefined,
+}));
 export type SearchResults = z.infer<typeof SearchResultsSchema>;
 
 /**
@@ -120,4 +237,3 @@ export const ExportMetadataSchema = z.object({
   exportedCount: z.number(),
 });
 export type ExportMetadata = z.infer<typeof ExportMetadataSchema>;
-


### PR DESCRIPTION
## Summary

The client and Zod schemas don't match the actual PCO API v0 response format, causing three cascading failures:

1. **Authentication hangs**: `apikey` query parameter should be `api_key` — the API silently rejects the auth and the request times out
2. **Empty results**: search uses `q` but the API expects `search_term`; type/status filter parameters also use different names
3. **Schema validation fails**: schemas expect flat `{id, title, type, status}` but the API returns nested `{work_id, latest_matching_version: {title}, legislation_type}`

### Changes

**`src/client.ts`**
- `apikey` → `api_key` (auth parameter)
- `q` → `search_term` (search parameter)
- `type` → `legislation_type` with value mapping (`regulation` → `secondary_legislation`)
- `status` → `legislation_status` with value mapping (`in-force` → `in_force`)
- `limit`/`offset` → `per_page`/`page`
- Handle paginated `{results: [...]}` wrapper on versions endpoint

**`src/models/index.ts`**
- Rewrite all Zod schemas to accept the actual API v0 response shape
- Use `.transform()` to normalize API responses into the existing `Work`/`Version`/`SearchResults` interfaces
- Maintains backward compatibility — CLI output format is unchanged
- Map `legislation_type`, `legislation_status`, `work_id`, and nested `latest_matching_version` to the flat interface consumers expect

## Test plan

- [x] `search --query "Resource Management" --type act` returns RMA 1991 and amendments
- [x] `search --query "walking access"` returns Walking Access Act 2008
- [x] `search --query "petroleum" --type regulation` returns Crown Minerals (Petroleum) Regulations
- [x] `search --type bill` returns current Bills before Parliament
- [x] JSON, table, and CSV output formats work
- [x] `--status in-force` filter works correctly
- [x] Build passes with `npm run build` (tsc)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Integrated support for the NZ Legislation API v0 (PCO) to fetch and normalize legislation data.
  * Enhanced handling of legislation metadata including versions, formats, and status information.

* **Bug Fixes**
  * Improved robustness in parsing version dates and handling varied API response structures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->