### PR TITLE
docs: add ANZ brand transition conductor track

### DIFF
--- a/.github/workflows/release-intent.yml
+++ b/.github/workflows/release-intent.yml
@@ -42,7 +42,7 @@ jobs:
             [ -z "$file" ] && continue
 
             case "$file" in
-              docs/*|conductor/*|.github/*|README.md|RELEASE_POLICY.md|SUPPORT_POLICY.md)
+              docs/*|conductor/*|.github/*|scripts/conductor-phase-review.mjs|README.md|RELEASE_POLICY.md|SUPPORT_POLICY.md)
                 ;;
               *)
                 REQUIRES_CHANGESET=1

--- a/conductor/README.md
+++ b/conductor/README.md
@@ -1,0 +1,19 @@
+# Conductor Workspace
+
+This directory contains Conductor planning records for this repository.
+
+## Layout
+
+- `status.md`
+  Current high-level view of active tracked work.
+- `tracks/`
+  Active tracks with their own `index.md`, `plan.md`, and `metadata.json`.
+
+## Current Active Tracks
+
+- `anz-brand-transition`
+
+## Operating Rule
+
+Add a track here only when it has real scope, explicit artifacts, and an owner
+or clear decision path.

--- a/conductor/status.md
+++ b/conductor/status.md
@@ -1,0 +1,31 @@
+# Conductor Status
+
+Last reviewed: 2026-03-14
+
+## Summary
+
+This file is the current Conductor overview for the repository branch.
+
+See also:
+
+- `README.md` for workspace rules
+- `tracks/anz-brand-transition/` for the active rename-planning track
+
+## Active Track Inventory
+
+| Track                  | Status  | Notes                                   |
+| ---------------------- | ------- | --------------------------------------- |
+| `anz-brand-transition` | PENDING | Staged rename plan for product and repo |
+
+## Current Read on Project State
+
+- The repository now has an explicit Conductor track for ANZ rename planning.
+- The product still ships as `nz-legislation-tool` and has not begun the rename
+  implementation yet.
+- The active tracked work here is planning and migration governance, not the
+  rename itself.
+
+## Recommended Next Step
+
+1. Complete Phase 1 naming-policy decisions for `anz-brand-transition`.
+2. Use the phase review gate before moving into implementation work.

--- a/conductor/tracks/anz-brand-transition/index.md
+++ b/conductor/tracks/anz-brand-transition/index.md
@@ -1,0 +1,48 @@
+# Track: ANZ Brand Transition
+
+## Context
+
+- [Specification](./spec.md)
+- [Implementation Plan](./plan.md)
+- [Metadata](./metadata.json)
+
+## Status
+
+🟡 PENDING - Track created to govern the rename from NZ-only branding to an
+ANZ-wide product identity
+
+## Summary
+
+Australian support means the product now has a mismatch between what it does
+and what it is called. The rename should be staged rather than immediate,
+because the repository name, npm package, CLI binary, GitHub Pages path,
+documentation URLs, configuration directories, and MCP identity are all tied to
+the existing `nz-legislation` / `nz-legislation-tool` naming.
+
+This track treats `anz-legislation` as the target repository name and `ANZ
+Legislation` as the target product identity. It deliberately separates the
+decision, compatibility policy, public-surface migration, and eventual cleanup
+so the transition can happen without breaking current users.
+
+## Intended Outcome
+
+- the repository can be renamed to `anz-legislation`
+- the product can be presented publicly as `ANZ Legislation`
+- package and CLI migration can happen with an explicit compatibility window
+- documentation, MCP, and website surfaces can be updated without orphaning the
+  current install base
+- every phase ends with a scripted Conductor review gate before work advances
+
+## Review Automation
+
+Use the phase-end review command at the end of each plan phase:
+
+`node scripts/conductor-phase-review.mjs --track anz-brand-transition --phase <n>`
+
+The command validates that the active track artifacts exist, that the named
+phase exists in the plan, and that the phase contains its own review gate.
+
+---
+
+**Track ID:** `anz-brand-transition`
+**Last Updated:** 2026-03-14

--- a/conductor/tracks/anz-brand-transition/metadata.json
+++ b/conductor/tracks/anz-brand-transition/metadata.json
@@ -1,0 +1,8 @@
+{
+  "track_id": "anz-brand-transition",
+  "type": "feature",
+  "status": "pending",
+  "created_at": "2026-03-14T11:00:00+11:00",
+  "updated_at": "2026-03-14T11:00:00+11:00",
+  "description": "Plan and execute the staged product, package, repository, and documentation transition from NZ-only branding to ANZ branding"
+}

--- a/conductor/tracks/anz-brand-transition/plan.md
+++ b/conductor/tracks/anz-brand-transition/plan.md
@@ -1,0 +1,162 @@
+# Plan: ANZ Brand Transition
+
+**Track ID:** anz-brand-transition  
+**Status:** 🟡 PENDING  
+**Priority:** 🔴 HIGH  
+**Last Updated:** 2026-03-14
+
+---
+
+## Summary
+
+This plan remediates the mismatch between the current NZ-only brand and the
+tool's emerging Australia + New Zealand scope. It uses a staged migration so
+the repository can move toward `anz-legislation` without breaking the current
+package, CLI, documentation, or MCP install base.
+
+---
+
+## Phase 1: Naming Decision and Compatibility Policy
+
+### Goals
+
+- confirm the target public name as `ANZ Legislation`
+- confirm the target repository name as `anz-legislation`
+- define compatibility windows for package, CLI, and docs migration
+- document what remains legacy versus what becomes canonical
+
+### Outputs
+
+- decision record for target names and migration principles
+- deprecation policy for old package and binary names
+- canonical list of renamed versus preserved public surfaces
+
+### Automated Review Gate
+
+- [ ] Run `node scripts/conductor-phase-review.mjs --track anz-brand-transition --phase 1`
+- [ ] Update `index.md`, `plan.md`, and `metadata.json` with the approved naming policy
+- [ ] Record any explicit exceptions before Phase 2 starts
+
+---
+
+## Phase 2: Internal Surface Abstraction
+
+### Goals
+
+- remove hard-coded NZ-only assumptions from product copy and metadata
+- identify every source-controlled occurrence of repo/package/binary/site naming
+- introduce a dual-branding implementation strategy where old and new names can coexist
+
+### Outputs
+
+- inventory of rename-sensitive files and runtime surfaces
+- implementation rules for dual-branding and alias support
+- updated internal references that should stop assuming NZ-only branding
+
+### Automated Review Gate
+
+- [ ] Run `node scripts/conductor-phase-review.mjs --track anz-brand-transition --phase 2`
+- [ ] Update track artifacts with the internal migration inventory
+- [ ] Confirm the remaining public rename work is sequenced and reversible
+
+---
+
+## Phase 3: Package and CLI Migration
+
+### Goals
+
+- define whether `anz-legislation` becomes the primary npm package or a meta/shim package first
+- preserve the existing installation path of `nz-legislation-tool`
+- introduce the future CLI command names without immediately removing `nzlegislation`
+
+### Outputs
+
+- package migration strategy
+- CLI alias strategy
+- release-note and deprecation messaging for current users
+
+### Constraints
+
+- no breaking CLI rename without a published compatibility window
+- no package rename without an explicit install-path migration plan
+
+### Automated Review Gate
+
+- [ ] Run `node scripts/conductor-phase-review.mjs --track anz-brand-transition --phase 3`
+- [ ] Update track artifacts with the chosen package and CLI migration strategy
+- [ ] Verify the plan still preserves a working path for existing users
+
+---
+
+## Phase 4: Repository, Documentation, and Site Migration
+
+### Goals
+
+- rename the GitHub repository to `anz-legislation`
+- update GitHub Pages paths, documentation links, badges, and edit URLs
+- update MCP metadata, release docs, and maintainer guides to the new repo identity
+
+### Outputs
+
+- repo rename checklist
+- docs/site migration checklist
+- MCP metadata and support-link migration checklist
+
+### Constraints
+
+- GitHub Pages path changes must be coordinated with documentation deployment
+- repository rename must account for branch protection, Actions links, and badges
+
+### Automated Review Gate
+
+- [ ] Run `node scripts/conductor-phase-review.mjs --track anz-brand-transition --phase 4`
+- [ ] Update track artifacts with the repository and docs migration outcome
+- [ ] Confirm no critical public links remain on the old repo path without redirects
+
+---
+
+## Phase 5: Deprecation and Legacy Cleanup
+
+### Goals
+
+- define the end of the compatibility window
+- remove or retire legacy names only after published notice and working replacement paths
+- ensure support and troubleshooting docs point to the new canonical identity
+
+### Outputs
+
+- deprecation completion checklist
+- final cleanup list for old names in code, docs, workflows, and support materials
+- closure criteria for the transition track
+
+### Automated Review Gate
+
+- [ ] Run `node scripts/conductor-phase-review.mjs --track anz-brand-transition --phase 5`
+- [ ] Update track artifacts with final deprecation decisions
+- [ ] Confirm whether the track can be marked complete or needs a follow-on cleanup track
+
+---
+
+## Immediate Recommendation
+
+Proceed with `ANZ Legislation` and `anz-legislation` as the target public names,
+but do not rename the npm package or CLI binaries in the same step as the repo
+rename. The least risky order is:
+
+1. agree naming policy
+2. prepare dual-branding internally
+3. introduce compatibility paths
+4. rename repo and docs surfaces
+5. deprecate old package and binary names later
+
+---
+
+## Exit Criteria
+
+This track is complete when:
+
+1. the repository identity is migrated to `anz-legislation`
+2. the product identity is publicly presented as `ANZ Legislation`
+3. package, CLI, MCP, and docs naming all have a documented canonical state
+4. a compatibility window is executed rather than implied
+5. each phase has been closed with the scripted Conductor review gate

--- a/conductor/tracks/anz-brand-transition/spec.md
+++ b/conductor/tracks/anz-brand-transition/spec.md
@@ -1,0 +1,124 @@
+# Specification: ANZ Brand Transition
+
+## Position
+
+Yes, the rename should begin now, but as a staged migration rather than a
+single-step switch.
+
+`anz-legislation` is a coherent target repository name because the product now
+serves both New Zealand and Australian legislation. It is broad enough to cover
+the current scope without pretending to be global. It also keeps the public
+surface concise and legible.
+
+The migration must still preserve continuity for existing users of:
+
+- the GitHub repository `edithatogo/nz-legislation`
+- the npm package `nz-legislation-tool`
+- the CLI binaries `nzlegislation` and `nzlegislation-mcp`
+- the current documentation and GitHub Pages URLs
+- the current local config and log directories under `.nz-legislation-tool`
+
+## Problem
+
+The product name currently implies New Zealand-only scope while the product now
+contains Australian jurisdiction support. That mismatch creates friction in:
+
+- repository visibility for users
+- documentation credibility
+- package naming and install expectations
+- CLI help and setup language
+- future jurisdiction expansion planning
+
+At the same time, renaming all public surfaces immediately would create
+avoidable user breakage and release confusion.
+
+## Scope
+
+This track governs the rename strategy and execution plan for:
+
+- product name
+- repository name
+- documentation and website naming
+- npm package naming strategy
+- CLI binary naming strategy
+- MCP server naming and metadata
+- local config/log directory strategy
+- backwards-compatibility and deprecation policy
+
+Out of scope:
+
+- implementing new jurisdictions
+- changing legal citation semantics
+- redesigning the CLI surface beyond naming/migration concerns
+
+## Target Naming
+
+The default target names for planning are:
+
+- Product name: `ANZ Legislation`
+- Repository name: `anz-legislation`
+- Preferred future package name: `anz-legislation`
+- Preferred future CLI binaries: `anzlegislation` and `anzlegislation-mcp`
+
+Legacy names remain valid during the compatibility window:
+
+- `nz-legislation-tool`
+- `nzlegislation`
+- `nzlegislation-mcp`
+- repo references to `edithatogo/nz-legislation`
+
+## Required Outcomes
+
+1. A canonical rename policy exists before public renaming starts.
+2. The repository rename to `anz-legislation` is planned and executed safely.
+3. A package migration strategy exists that does not strand the existing npm
+   install base.
+4. CLI naming migration is staged and documented.
+5. Docs, GitHub Pages, and MCP metadata are updated consistently.
+6. Legacy names have an explicit deprecation window and removal criteria.
+7. Every implementation phase is gated by a scripted Conductor review step.
+
+## Acceptance Criteria
+
+- A new active Conductor track documents the ANZ rename strategy.
+- The plan names `anz-legislation` as the repository target.
+- The plan explicitly distinguishes product rename, package rename, CLI rename,
+  repo rename, and docs/site rename.
+- The plan preserves legacy install paths during a compatibility window instead
+  of forcing immediate breakage.
+- Each phase in the plan has an `Automated Review Gate` subsection.
+- The repository contains a reusable review command:
+  `node scripts/conductor-phase-review.mjs --track anz-brand-transition --phase <n>`.
+- Conductor workspace summary includes this track in active inventory.
+
+## Risks
+
+- npm package rename can break install scripts and automation if executed
+  without alias or shim strategy.
+- GitHub Pages path and docs search indexes may break if the repo name changes
+  without parallel updates.
+- Existing references in docs and workflows are widespread and require
+  deliberate sequencing.
+- `ANZ` branding is appropriate for current scope, but the decision should be
+  revisited if the product expands beyond Australia and New Zealand.
+
+## Evidence Sources
+
+Primary evidence for migration scope includes:
+
+- `package.json`
+- `README.md`
+- `src/cli.ts`
+- `src/mcp/server.ts`
+- `src/config.ts`
+- `src/utils/logger.ts`
+- `src/utils/secure-config.ts`
+- `src/utils/version.ts`
+- `docs/`
+- `.github/workflows/`
+
+## Follow-On Execution
+
+This track is the planning and control surface for the rename. Implementation
+work should be delivered phase by phase against this plan rather than through a
+single mass rename commit.

--- a/scripts/conductor-phase-review.mjs
+++ b/scripts/conductor-phase-review.mjs
@@ -1,0 +1,152 @@
+import fs from 'node:fs';
+import path from 'node:path';
+
+const CONDUCTOR_DIR = 'conductor';
+const TRACKS_DIR = 'tracks';
+const TRACK_REQUIRED_FILES = [
+  'index.md',
+  'plan.md',
+  'metadata.json',
+];
+
+function parseArgs(argv) {
+  const args = {
+    track: '',
+    phase: '',
+    allowOpenTasks: false,
+  };
+
+  for (let i = 0; i < argv.length; i += 1) {
+    const arg = argv[i];
+    const next = argv[i + 1];
+
+    if ((arg === '--track' || arg === '-t') && next) {
+      args.track = next;
+      i += 1;
+      continue;
+    }
+
+    if ((arg === '--phase' || arg === '-p') && next) {
+      args.phase = next;
+      i += 1;
+      continue;
+    }
+
+    if (arg === '--allow-open-tasks') {
+      args.allowOpenTasks = true;
+      continue;
+    }
+  }
+
+  return args;
+}
+
+function fail(message) {
+  console.error(`Conductor phase review failed: ${message}`);
+  process.exit(1);
+}
+
+function escapeRegex(value) {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+function readText(filePath) {
+  return fs.readFileSync(filePath, 'utf8');
+}
+
+function countUncheckedTasks(section) {
+  const matches = section.match(/^- \[ \] /gm);
+  return matches ? matches.length : 0;
+}
+
+const { track, phase, allowOpenTasks } = parseArgs(process.argv.slice(2));
+
+if (!track || !phase) {
+  fail('usage: node scripts/conductor-phase-review.mjs --track <track-id> --phase <phase-number>');
+}
+
+if (!/^\d+$/.test(phase) || Number(phase) < 1) {
+  fail(`phase must be a positive integer, received: ${phase}`);
+}
+
+const rootDir = process.cwd();
+const trackDir = path.join(rootDir, CONDUCTOR_DIR, TRACKS_DIR, track);
+
+if (!fs.existsSync(trackDir)) {
+  fail(`track directory not found: ${trackDir}`);
+}
+
+for (const file of TRACK_REQUIRED_FILES) {
+  const filePath = path.join(trackDir, file);
+  if (!fs.existsSync(filePath)) {
+    fail(`required track file is missing: ${CONDUCTOR_DIR}/${TRACKS_DIR}/${track}/${file}`);
+  }
+}
+
+const planPath = path.join(trackDir, 'plan.md');
+const indexPath = path.join(trackDir, 'index.md');
+const metadataPath = path.join(trackDir, 'metadata.json');
+
+const plan = readText(planPath);
+const index = readText(indexPath);
+const metadata = (() => {
+  try {
+    return JSON.parse(readText(metadataPath));
+  } catch (error) {
+    fail(
+      `failed to parse ${CONDUCTOR_DIR}/${TRACKS_DIR}/${track}/metadata.json: ${error.message}`
+    );
+  }
+})();
+
+const escapedPhase = escapeRegex(phase);
+const phaseHeader = new RegExp(`## Phase ${escapedPhase}:`, 'i');
+if (!phaseHeader.test(plan)) {
+  fail(`phase ${phase} was not found in ${CONDUCTOR_DIR}/${TRACKS_DIR}/${track}/plan.md`);
+}
+
+const phaseSplit = plan.split(new RegExp(`## Phase ${escapedPhase}:`, 'i'));
+const phaseBody = phaseSplit[1]?.split(/\n## Phase \d+:/i)[0] ?? '';
+
+if (!/Automated Review Gate/i.test(phaseBody)) {
+  fail(`phase ${phase} is missing an "Automated Review Gate" section`);
+}
+
+const commandPattern = new RegExp(
+  `node scripts/conductor-phase-review\\.mjs --track ${escapeRegex(track)} --phase ${escapedPhase}`,
+  'i'
+);
+if (!commandPattern.test(phaseBody)) {
+  fail(`phase ${phase} does not contain its own conductor review command`);
+}
+
+const uncheckedTasks = countUncheckedTasks(phaseBody);
+const statusLine =
+  index.match(/## Status\s+([\s\S]*?)## /)?.[1]?.trim() ??
+  index.match(/## Status\s+([\s\S]*)$/)?.[1]?.trim() ??
+  'status section not found';
+
+console.log('Conductor Phase Review');
+console.log(`Track: ${track}`);
+console.log(`Phase: ${phase}`);
+console.log(`Metadata status: ${metadata.status ?? 'unknown'}`);
+console.log(`Metadata updated_at: ${metadata.updated_at ?? 'missing'}`);
+console.log(`Unchecked tasks in phase section: ${uncheckedTasks}`);
+console.log(`Index status summary: ${statusLine}`);
+console.log('Required files: ok');
+console.log('Automated review gate: ok');
+
+if (uncheckedTasks > 0) {
+  if (allowOpenTasks) {
+    console.log(
+      'Result: review command completed in informational mode, but this phase still contains unchecked tasks.'
+    );
+    process.exit(0);
+  } else {
+    fail(
+      'phase review found unchecked tasks in the phase section; close or explicitly bypass them before treating this phase as complete'
+    );
+  }
+}
+
+console.log('Result: review command completed and no unchecked tasks remain in this phase section.');


### PR DESCRIPTION
## Summary
- add a minimal conductor workspace to the remote branch
- add an active ANZ brand transition track with spec, plan, and metadata
- add a reusable phase-review script for phase-end gating without coupling it to package release semantics
- treat the conductor phase-review helper as governance-only in the release-intent workflow

## Validation
- node --check scripts/conductor-phase-review.mjs
- node scripts/conductor-phase-review.mjs --track anz-brand-transition --phase 1 --allow-open-tasks