### PR TITLE
docs: normalize conductor workspace structure

### DIFF
--- a/conductor/README.md
+++ b/conductor/README.md
@@ -1,19 +1,42 @@
 # Conductor Workspace
 
-This directory contains Conductor planning records for this repository.
+This directory is the local source of truth for project-side Conductor records
+in this repository.
 
 ## Layout
 
 - `status.md`
-  Current high-level view of active tracked work.
+  Authoritative overview of current active, archived, backlog, and template
+  state.
 - `tracks/`
-  Active tracks with their own `index.md`, `plan.md`, and `metadata.json`.
+  Active tracks only. A track belongs here only when it has current ownership
+  and real Conductor artifacts.
+- `backlog/`
+  Reserved or deferred track names that should not appear as active work yet.
+- `templates/`
+  Reusable template material that should not appear in active inventory.
+- `archive/`
+  Historical completed or retired tracks retained for context.
+
+## Active Track Standard
+
+Each active track should have:
+
+1. `index.md`
+2. `plan.md`
+3. `metadata.json`
+
+Optional supporting files such as `spec.md` or `PROGRESS_LOG.md` are encouraged
+when they materially improve traceability.
 
 ## Current Active Tracks
 
+- `release-governance-modernization`
+- `documentation-site-completion`
+- `documentation-site-enhancements`
 - `anz-brand-transition`
 
 ## Operating Rule
 
-Add a track here only when it has real scope, explicit artifacts, and an owner
-or clear decision path.
+If a named effort does not yet have a real owner, scope, and plan, keep it in
+`backlog/` rather than `tracks/`.

--- a/conductor/archive/README.md
+++ b/conductor/archive/README.md
@@ -1,0 +1,29 @@
+# Conductor Archive
+
+This directory contains historical Conductor tracks that are no longer part of
+the active delivery inventory.
+
+## Archived Tracks
+
+- `cicd-automation-optimization`
+- `code-hardening-maturation`
+- `comprehensive-testing`
+- `developer-experience-enhancement`
+- `documentation-optimization`
+- `documentation-site-phase-8`
+- `mcp-server-implementation`
+- `performance-scalability`
+- `testing-warning-hardening`
+- `track-12-australian-expansion`
+- `typescript-cli-implementation`
+
+## Usage
+
+Use the archive for:
+
+- prior implementation context
+- old planning assumptions
+- historical evidence of completed or retired work
+
+Do not treat archive entries as active unless they are explicitly restored into
+`conductor/tracks`.

--- a/conductor/backlog/README.md
+++ b/conductor/backlog/README.md
@@ -1,0 +1,26 @@
+# Conductor Backlog
+
+This directory holds named track placeholders that should not appear in the
+active `conductor/tracks` inventory until they have real Conductor artifacts and
+current ownership.
+
+## Current Backlog Entries
+
+- `australian-legislation-implementation`
+  Reserved name only. No active local Conductor plan has been authored.
+- `p1-legislative-volatility`
+  Removed from active product-track inventory because the real detailed track
+  exists under `research-conductor/conductor/tracks/p1-legislative-volatility`.
+- `p1-policy-whiplash`
+  Reserved name only. No active local Conductor plan has been authored.
+- `track-11-advanced-automation`
+  Reserved name only. No active local Conductor plan has been authored.
+
+## Promotion Rule
+
+Move a backlog entry back into `conductor/tracks` only when it has:
+
+1. `index.md`
+2. `plan.md`
+3. `metadata.json`
+4. a current owner and scope

--- a/conductor/backlog/australian-legislation-implementation/index.md
+++ b/conductor/backlog/australian-legislation-implementation/index.md
@@ -1,0 +1,21 @@
+# Track: Australian Legislation Implementation
+
+## Status
+
+⚪ STUB - Directory exists but no Conductor artifacts have been authored yet
+
+## Summary
+
+This track name reserves space for Australian legislation implementation work,
+but it is not yet an active Conductor track in this workspace.
+
+## Required Next Artifacts
+
+- `spec.md`
+- `plan.md`
+- `metadata.json`
+
+## Action
+
+Either author the missing track documents before work starts or archive/remove
+this directory if the effort has moved elsewhere.

--- a/conductor/backlog/australian-legislation-implementation/metadata.json
+++ b/conductor/backlog/australian-legislation-implementation/metadata.json
@@ -1,0 +1,8 @@
+{
+  "track_id": "australian-legislation-implementation",
+  "type": "placeholder",
+  "status": "stub",
+  "created_at": "2026-03-14T00:00:00+11:00",
+  "updated_at": "2026-03-14T00:00:00+11:00",
+  "description": "Reserved track directory without authored Conductor artifacts"
+}

--- a/conductor/backlog/p1-legislative-volatility/index.md
+++ b/conductor/backlog/p1-legislative-volatility/index.md
@@ -1,0 +1,20 @@
+# Track: P1 Legislative Volatility
+
+## Status
+
+⚪ STUB - Priority placeholder only
+
+## Summary
+
+This directory currently functions as a placeholder for a potential P1 track.
+No specification, execution plan, or metadata has been captured yet.
+
+## Required Next Artifacts
+
+- `spec.md`
+- `plan.md`
+- `metadata.json`
+
+## Action
+
+Define the actual scope before treating this as active work.

--- a/conductor/backlog/p1-legislative-volatility/metadata.json
+++ b/conductor/backlog/p1-legislative-volatility/metadata.json
@@ -1,0 +1,8 @@
+{
+  "track_id": "p1-legislative-volatility",
+  "type": "placeholder",
+  "status": "stub",
+  "created_at": "2026-03-14T00:00:00+11:00",
+  "updated_at": "2026-03-14T00:00:00+11:00",
+  "description": "Reserved P1 track name without authored scope, plan, or evidence"
+}

--- a/conductor/backlog/p1-policy-whiplash/index.md
+++ b/conductor/backlog/p1-policy-whiplash/index.md
@@ -1,0 +1,20 @@
+# Track: P1 Policy Whiplash
+
+## Status
+
+⚪ STUB - Priority placeholder only
+
+## Summary
+
+This directory currently functions as a placeholder for a potential P1 track.
+No specification, execution plan, or metadata has been captured yet.
+
+## Required Next Artifacts
+
+- `spec.md`
+- `plan.md`
+- `metadata.json`
+
+## Action
+
+Define the actual scope before treating this as active work.

--- a/conductor/backlog/p1-policy-whiplash/metadata.json
+++ b/conductor/backlog/p1-policy-whiplash/metadata.json
@@ -1,0 +1,8 @@
+{
+  "track_id": "p1-policy-whiplash",
+  "type": "placeholder",
+  "status": "stub",
+  "created_at": "2026-03-14T00:00:00+11:00",
+  "updated_at": "2026-03-14T00:00:00+11:00",
+  "description": "Reserved P1 track name without authored scope, plan, or evidence"
+}

--- a/conductor/backlog/track-11-advanced-automation/index.md
+++ b/conductor/backlog/track-11-advanced-automation/index.md
@@ -1,0 +1,21 @@
+# Track: Track 11 - Advanced Automation
+
+## Status
+
+⚪ STUB - Name reserved, but no Conductor artifacts exist
+
+## Summary
+
+This directory indicates a prior intent to track advanced automation work.
+No current specification, plan, or metadata documents scope or progress.
+
+## Required Next Artifacts
+
+- `spec.md`
+- `plan.md`
+- `metadata.json`
+
+## Action
+
+Either restore the missing track documents or archive/remove the placeholder if
+the work no longer belongs in the active track set.

--- a/conductor/backlog/track-11-advanced-automation/metadata.json
+++ b/conductor/backlog/track-11-advanced-automation/metadata.json
@@ -1,0 +1,8 @@
+{
+  "track_id": "track-11-advanced-automation",
+  "type": "placeholder",
+  "status": "stub",
+  "created_at": "2026-03-14T00:00:00+11:00",
+  "updated_at": "2026-03-14T00:00:00+11:00",
+  "description": "Reserved track name without authored Conductor plan or progress record"
+}

--- a/conductor/status.md
+++ b/conductor/status.md
@@ -4,28 +4,61 @@ Last reviewed: 2026-03-14
 
 ## Summary
 
-This file is the current Conductor overview for the repository branch.
+This file is the authoritative Conductor workspace overview for this repository.
+The workspace currently contains a mix of complete records, pending work, and
+backlog/template material that has now been separated from active tracks.
 
 See also:
 
-- `README.md` for workspace rules
-- `tracks/anz-brand-transition/` for the active rename-planning track
+- `README.md` for workspace operating rules
+- `archive/README.md` for archived track inventory
+- `backlog/README.md` for backlog promotion rules
 
 ## Active Track Inventory
 
-| Track                  | Status  | Notes                                   |
-| ---------------------- | ------- | --------------------------------------- |
-| `anz-brand-transition` | PENDING | Staged rename plan for product and repo |
+| Track                              | Status   | Notes                                     |
+| ---------------------------------- | -------- | ----------------------------------------- |
+| `release-governance-modernization` | COMPLETE | Fully documented and marked complete      |
+| `documentation-site-enhancements`  | PENDING  | Optional post-launch work not yet started |
+| `documentation-site-completion`    | COMPLETE | Parent completion record restored         |
+| `anz-brand-transition`             | PENDING  | Staged rename plan for product and repo   |
+
+## Archived Tracks
+
+Archived track count: `11`
+
+The archive contains prior completed or retired efforts and should be treated as
+historical context rather than active delivery scope.
+
+## Backlog Entries
+
+Backlog entry count: `4`
+
+The backlog contains reserved track names that are not part of current active
+delivery. One of them, `p1-legislative-volatility`, is intentionally tracked in
+detail under `research-conductor` instead of this product-side Conductor tree.
 
 ## Current Read on Project State
 
-- The repository now has an explicit Conductor track for ANZ rename planning.
-- The product still ships as `nz-legislation-tool` and has not begun the rename
-  implementation yet.
-- The active tracked work here is planning and migration governance, not the
-  rename itself.
+- Conductor now has a clean active-track inventory.
+- Two active tracks are explicitly complete.
+- Two active tracks are explicitly pending.
+- The documentation enhancement track no longer contradicts itself about launch
+  status.
+- The missing parent record for documentation site completion has been
+  restored.
+- The ANZ brand transition is now tracked as a separate staged migration rather
+  than an implicit future rename.
+- The former template track has been moved out of active inventory to
+  `conductor/templates`.
+- Former stub tracks have been moved out of active inventory to
+  `conductor/backlog`.
 
-## Recommended Next Step
+## Recommended Next Cleanup
 
-1. Complete Phase 1 naming-policy decisions for `anz-brand-transition`.
-2. Use the phase review gate before moving into implementation work.
+1. Track future status changes by updating `metadata.json` alongside each active
+   track’s `index.md` and `plan.md`.
+2. Promote backlog entries back into `conductor/tracks` only when they gain a
+   real owner, scope, and plan.
+3. Decide whether any archived tracks should be consolidated or indexed more
+   explicitly for discovery.

--- a/conductor/templates/maintenance-automation-template/index.md
+++ b/conductor/templates/maintenance-automation-template/index.md
@@ -1,0 +1,22 @@
+# Track Template: Maintenance Automation
+
+## Status
+
+⚪ TEMPLATE - Not an active track
+
+## Summary
+
+This directory is a template placeholder and should not be counted as active
+delivery work until it is copied or renamed into a real track with its own
+artifacts.
+
+## Required Next Artifacts
+
+- `spec.md`
+- `plan.md`
+- `metadata.json`
+
+## Action
+
+Keep as a template reference or move it out of `conductor/tracks` if only
+active tracks should live there.

--- a/conductor/templates/maintenance-automation-template/metadata.json
+++ b/conductor/templates/maintenance-automation-template/metadata.json
@@ -1,0 +1,8 @@
+{
+  "track_id": "TEMPLATE-maintenance-automation",
+  "type": "template",
+  "status": "template",
+  "created_at": "2026-03-14T00:00:00+11:00",
+  "updated_at": "2026-03-14T00:00:00+11:00",
+  "description": "Template directory retained under tracks pending further cleanup"
+}

--- a/conductor/tracks/documentation-site-completion/index.md
+++ b/conductor/tracks/documentation-site-completion/index.md
@@ -1,0 +1,35 @@
+# Track: Documentation Site Completion
+
+## Context
+
+- [Implementation Plan](./plan.md)
+- [Metadata](./metadata.json)
+
+## Status
+
+🟢 COMPLETE - Parent documentation site launch record restored
+
+## Summary
+
+This track restores the missing local Conductor record for the documentation
+site launch. The site is treated as launched successfully without optional
+search, analytics, or feedback tooling, which remain separated into the
+post-launch enhancement track.
+
+## Outcome
+
+- launch completion is now represented on disk
+- parent/child relationship with `documentation-site-enhancements` is explicit
+- optional polish work is no longer conflated with launch-critical work
+
+## Evidence
+
+- `docs/documentation-site-setup.md`
+- `docs/documentation-site-config.md`
+- `docs/LAUNCH_MAINTENANCE.md`
+- `conductor/tracks/documentation-site-enhancements/index.md`
+
+---
+
+**Track ID:** `documentation-site-completion`
+**Last Updated:** 2026-03-14

--- a/conductor/tracks/documentation-site-completion/metadata.json
+++ b/conductor/tracks/documentation-site-completion/metadata.json
@@ -1,0 +1,8 @@
+{
+  "track_id": "documentation-site-completion",
+  "type": "feature",
+  "status": "complete",
+  "created_at": "2026-03-11T00:00:00+11:00",
+  "updated_at": "2026-03-14T00:00:00+11:00",
+  "description": "Backfilled completion record for the documentation site launch and parent-track handoff to post-launch enhancements"
+}

--- a/conductor/tracks/documentation-site-completion/plan.md
+++ b/conductor/tracks/documentation-site-completion/plan.md
@@ -1,0 +1,76 @@
+# Plan: Documentation Site Completion
+
+**Track ID:** documentation-site-completion  
+**Status:** 🟢 COMPLETE  
+**Priority:** 🟡 MEDIUM  
+**Last Updated:** 2026-03-14
+
+---
+
+## Summary
+
+This plan restores the completion record for the documentation site launch.
+The site was launched without optional search and analytics features, and those
+follow-on items are intentionally tracked in the separate
+`documentation-site-enhancements` track.
+
+---
+
+## Phase 1: Documentation Foundation
+
+### Completed
+
+- [x] Establish source documentation under `docs/`
+- [x] Create user and developer guide structure
+- [x] Create accessibility and search guidance
+- [x] Create documentation site setup/configuration references
+
+### Evidence
+
+- `docs/user-guide/index.md`
+- `docs/developer-guide/index.md`
+- `docs/user-guide/accessibility-search.md`
+- `docs/documentation-site-setup.md`
+- `docs/documentation-site-config.md`
+
+---
+
+## Phase 2: Launch Readiness
+
+### Completed
+
+- [x] Define launch and maintenance operating guidance
+- [x] Separate launch-critical work from optional post-launch enhancements
+- [x] Establish that search and analytics are not required for launch
+
+### Evidence
+
+- `docs/LAUNCH_MAINTENANCE.md`
+- `conductor/tracks/documentation-site-enhancements/plan.md`
+
+---
+
+## Phase 3: Outcome Recording
+
+### Completed
+
+- [x] Mark the site completion track as launched successfully
+- [x] Hand optional polish items to the enhancement track
+- [x] Restore the missing local Conductor record for the parent track
+
+### Evidence
+
+- `conductor/tracks/documentation-site-completion/index.md`
+- `conductor/tracks/documentation-site-enhancements/index.md`
+
+---
+
+## Exit Criteria
+
+This track is complete because:
+
+1. the documentation launch is treated as accomplished in the local Conductor
+   workspace
+2. the enhancement work is explicitly split into a separate pending track
+3. the workspace now has a parent record on disk instead of only downstream
+   references to it

--- a/conductor/tracks/documentation-site-enhancements/index.md
+++ b/conductor/tracks/documentation-site-enhancements/index.md
@@ -1,0 +1,53 @@
+# Track: Documentation Site - Post-Launch Enhancements
+
+## Context
+
+- [Specification](./spec.md) _(future)_
+- [Implementation Plan](./plan.md)
+- [Metadata](./metadata.json) _(future)_
+
+## Parent Track
+
+Documentation Site Completion ✅ - Launched successfully without search/analytics
+
+## Status
+
+⏳ PENDING - Post-launch enhancements not yet started
+
+## Summary
+
+Post-launch enhancements including search functionality (DocSearch), analytics (Google Analytics), user feedback collection, and continuous improvements. These items are **optional** and **not required for launch**.
+
+The parent documentation site is treated as already launched. This track remains
+pending because the optional post-launch enhancement work has not yet been
+executed.
+
+## Timeline
+
+4-6 hours of work + 1-2 week wait for DocSearch approval
+
+## Priority
+
+🟡 MEDIUM (Enhancement track, not required for core functionality)
+
+## Phases
+
+1. **Search Implementation** - DocSearch setup (1-2 weeks, external dependency)
+2. **Analytics & Monitoring** - Google Analytics, uptime monitoring (1-2 hours)
+3. **User Feedback Collection** - Feedback widgets, edit links (2-3 hours)
+4. **Continuous Improvement** - Monthly/quarterly audits (ongoing)
+5. **Version Management** - Documentation versioning (as needed)
+
+## Success Criteria
+
+- ✅ Search functional (DocSearch)
+- ✅ Analytics configured (Google Analytics)
+- ✅ Feedback mechanism accessible
+- ✅ Performance score >90
+- ✅ Accessibility WCAG 2.1 AA
+- ✅ Uptime >99%
+
+---
+
+**Created:** 2026-03-11  
+**Track ID:** `documentation-site-enhancements`

--- a/conductor/tracks/documentation-site-enhancements/metadata.json
+++ b/conductor/tracks/documentation-site-enhancements/metadata.json
@@ -1,0 +1,8 @@
+{
+  "track_id": "documentation-site-enhancements",
+  "type": "enhancement",
+  "status": "pending",
+  "created_at": "2026-03-11T00:00:00+11:00",
+  "updated_at": "2026-03-14T00:00:00+11:00",
+  "description": "Optional post-launch documentation site improvements including search, analytics, feedback, and ongoing quality work"
+}

--- a/conductor/tracks/documentation-site-enhancements/plan.md
+++ b/conductor/tracks/documentation-site-enhancements/plan.md
@@ -1,0 +1,287 @@
+# Track: Documentation Site - Post-Launch Enhancements
+
+**Track ID:** documentation-site-enhancements  
+**Parent:** Documentation Site Completion ✅  
+**Status:** ⏳ PENDING (post-launch enhancements not yet started)  
+**Priority:** 🟡 MEDIUM  
+**Timeline:** 2-4 weeks post-launch
+
+---
+
+## Summary
+
+This track handles post-launch enhancements to the documentation site, including search functionality, analytics, and continuous improvements. These items are **not required for launch** and can be implemented after the site is live.
+
+---
+
+## Phase 1: Search Implementation (1-2 weeks)
+
+**Dependency:** DocSearch application approval (external, 1-2 weeks)
+
+### Tasks
+
+- [ ] **1.1** Apply for Algolia DocSearch
+  - Submit application at https://docsearch.algolia.com/apply/
+  - URL: `https://edithatogo.github.io/nz-legislation/`
+  - Repository: `https://github.com/edithatogo/nz-legislation`
+  - **Timeline:** 10 minutes to apply
+
+- [ ] **1.2** Wait for approval
+  - **Timeline:** 1-2 weeks (external dependency)
+  - **Status:** ⏳ BLOCKED (cannot proceed until DocSearch approval is granted)
+
+- [ ] **1.3** Configure DocSearch credentials
+  - Add to `documentation-site/.env`:
+    ```bash
+    ALGOLIA_APP_ID=<provided_by_algolia>
+    ALGOLIA_API_KEY=<provided_by_algolia>
+    ```
+  - Verify config in `docusaurus.config.ts`:
+    ```typescript
+    algolia: {
+      appId: process.env.ALGOLIA_APP_ID || 'temp_app_id',
+      apiKey: process.env.ALGOLIA_API_KEY || 'temp_api_key',
+      indexName: 'nz-legislation',
+      contextualSearch: true,
+    },
+    ```
+
+- [ ] **1.4** Test search functionality
+  - Test basic search queries
+  - Verify search results accuracy
+  - Test keyboard navigation
+  - Test mobile search
+
+- [ ] **1.5** Deploy search-enabled site
+  - Commit and push changes
+  - Verify search works in production
+
+**Outputs:**
+
+- ✅ Search bar functional
+- ✅ Search results accurate
+- ✅ Mobile search working
+
+---
+
+## Phase 2: Analytics & Monitoring (1-2 hours)
+
+### Tasks
+
+- [ ] **2.1** Create Google Analytics 4 property
+  - Visit https://analytics.google.com/
+  - Create property: "NZ Legislation Tool"
+  - Get Measurement ID (format: G-XXXXXXXXXX)
+  - **Timeline:** 15 minutes
+
+- [ ] **2.2** Configure analytics
+  - Add to `documentation-site/.env`:
+    ```bash
+    GA_TRACKING_ID=G-XXXXXXXXXX
+    ```
+  - Enable in `docusaurus.config.ts`:
+    ```typescript
+    googleAnalytics: {
+      trackingID: process.env.GA_TRACKING_ID || 'G-XXXXXXXXXX',
+      anonymizeIP: true,
+    },
+    ```
+
+- [ ] **2.3** Verify analytics working
+  - Deploy changes
+  - Check GA real-time reporting
+  - Verify page views tracked
+
+- [ ] **2.4** Set up uptime monitoring (OPTIONAL)
+  - Create UptimeRobot account
+  - Add monitor for `https://edithatogo.github.io/nz-legislation/`
+  - Configure email alerts
+  - **Timeline:** 20 minutes
+
+- [ ] **2.5** Configure error tracking (OPTIONAL/FUTURE)
+  - Evaluate Sentry.io
+  - Add error tracking script
+  - Configure error alerts
+  - **Timeline:** 1 hour
+
+**Outputs:**
+
+- ✅ Google Analytics tracking
+- ✅ Uptime monitoring (optional)
+- ✅ Error tracking (optional/future)
+
+---
+
+## Phase 3: User Feedback Collection (2-3 hours)
+
+### Tasks
+
+- [ ] **3.1** Add feedback widget
+  - Option A: Simple GitHub link
+    ```jsx
+    <p>
+      Was this page helpful?
+      <a href="https://github.com/edithatogo/nz-legislation/issues">Report an issue</a>
+    </p>
+    ```
+  - Option B: Feedback form service (for example, Google Forms)
+  - Option C: Dedicated feedback tool (Canny, UserVoice)
+  - **Timeline:** 30 minutes
+
+- [ ] **3.2** Add "Edit this page" links
+  - Configure in `docusaurus.config.ts`:
+    ```typescript
+    editUrl: 'https://github.com/edithatogo/nz-legislation/tree/main/nz-legislation-tool/documentation-site/docs',
+    ```
+  - Verify links work on all pages
+
+- [ ] **3.3** Set up feedback review process
+  - Weekly review of feedback
+  - Triage into GitHub issues
+  - Respond to users
+
+**Outputs:**
+
+- ✅ Feedback mechanism in place
+- ✅ Review process documented
+
+---
+
+## Phase 4: Continuous Improvement (Ongoing)
+
+### Tasks
+
+- [ ] **4.1** Monthly analytics review
+  - Review top pages
+  - Identify drop-off points
+  - Track user flow
+  - **Frequency:** Monthly
+
+- [ ] **4.2** Quarterly content audit
+  - Check for outdated information
+  - Update screenshots
+  - Verify all links
+  - **Frequency:** Quarterly
+
+- [ ] **4.3** Accessibility improvements
+  - Run Lighthouse audit
+  - Fix accessibility issues
+  - Target: WCAG 2.1 AA compliance
+  - **Frequency:** Quarterly
+
+- [ ] **4.4** Performance optimization
+  - Run Lighthouse performance audit
+  - Optimize images
+  - Improve load time
+  - Target: >90 performance score
+  - **Frequency:** Quarterly
+
+- [ ] **4.5** User feedback implementation
+  - Review feedback from Phase 3
+  - Prioritize improvements
+  - Implement high-impact changes
+  - **Frequency:** Ongoing
+
+**Outputs:**
+
+- ✅ Monthly analytics reports
+- ✅ Quarterly improvement updates
+
+---
+
+## Phase 5: Version Management (As Needed)
+
+### Tasks
+
+- [ ] **5.1** Create version management documentation
+  - Create `docs/VERSIONING.md`
+  - Document when to create versions
+  - Document how to create versions
+  - **Timeline:** 30 minutes
+
+- [ ] **5.2** Create new documentation version (when needed)
+  - Run: `npm run docusaurus docs:version 2.0.0`
+  - Update `versions.json`
+  - Test version switching
+  - **Trigger:** Major releases
+
+- [ ] **5.3** Maintain versioned documentation
+  - Update current version continuously
+  - Archive old versions as needed
+  - Document breaking changes
+
+**Outputs:**
+
+- ✅ Version management process documented
+- ✅ Versions created as needed
+
+---
+
+## Success Criteria
+
+| Criterion     | Target     | Measurement            |
+| ------------- | ---------- | ---------------------- |
+| Search        | Functional | DocSearch working      |
+| Analytics     | Configured | GA tracking active     |
+| Feedback      | Accessible | Link on every page     |
+| Uptime        | >99%       | UptimeRobot monitoring |
+| Performance   | >90        | Lighthouse score       |
+| Accessibility | AA         | Lighthouse audit       |
+
+---
+
+## Timeline
+
+| Phase                | Duration  | Dependencies      |
+| -------------------- | --------- | ----------------- |
+| Phase 1: Search      | 1-2 weeks | Site must be live |
+| Phase 2: Analytics   | 1-2 hours | None              |
+| Phase 3: Feedback    | 2-3 hours | None              |
+| Phase 4: Improvement | Ongoing   | Phases 1-3        |
+| Phase 5: Versioning  | As needed | Major releases    |
+
+**Total Time:** 4-6 hours + 1-2 week wait for DocSearch
+
+---
+
+## Resources
+
+### Configuration Files
+
+- `docusaurus.config.ts` - Main config
+- `.env.example` - Environment template
+- `sidebars.ts` - Navigation
+
+### External Services
+
+- [Algolia DocSearch](https://docsearch.algolia.com/)
+- [Google Analytics](https://analytics.google.com/)
+- [UptimeRobot](https://uptimerobot.com/)
+- [Sentry](https://sentry.io/)
+
+### Documentation
+
+- [Docusaurus Search](https://docusaurus.io/docs/search)
+- [Docusaurus Analytics](https://docusaurus.io/docs/api/plugins/@docusaurus/plugin-google-analytics)
+- [Docusaurus Versioning](https://docusaurus.io/docs/versioning)
+
+---
+
+## Relationship to Parent Track
+
+**Parent Track:** Documentation Site Completion ✅
+
+This enhancement track is **optional** and **not required for launch**. The documentation site can launch successfully without:
+
+- ❌ Search functionality (users can navigate via sidebar)
+- ❌ Analytics (can be added later)
+- ❌ Feedback widgets (can use GitHub issues directly)
+
+**Recommendation:** The parent launch is treated as complete. Implement these
+enhancements only when post-launch polish becomes a priority.
+
+---
+
+**Created:** 2026-03-11  
+**Status:** ⏳ PENDING (post-launch enhancements not yet started)  
+**Priority:** 🟡 MEDIUM

--- a/conductor/tracks/release-governance-modernization/PROGRESS_LOG.md
+++ b/conductor/tracks/release-governance-modernization/PROGRESS_LOG.md
@@ -1,0 +1,46 @@
+# Progress Log: Release Governance Modernization
+
+## 2026-03-12
+
+### Implemented baseline governance
+
+- Canonical release topology established around `main`, `next`, `CI`,
+  `Release Stable`, and `Release Next`
+- Stable and prerelease workflows hardened
+- npm trusted publishing enabled for stable publishing
+- GitHub Packages mirror configured
+- `nz-legislation-tool@1.2.0` published as the stable MCP-enabled package
+- GitHub release `v1.2.0` created
+
+### Documented governance
+
+- Added release policy and support policy
+- Added maintainer guides and release-captain checklist
+- Added release topology ADR
+- Added legacy master branch ADR
+- Added Australian release readiness note
+
+### Corrected policy drift
+
+- Updated policy to reflect the actual shipped decision that MCP was an
+  additive `1.2.0` release, not a major `2.0.0`
+- Updated prerelease language so `next` is treated as a governed lane rather
+  than automatically the next major line
+
+### Track repair
+
+- Rebuilt this Conductor track folder after discovering the directory existed
+  but contained no files
+- Re-linked the track to the actual governance outputs that were implemented in
+  the active tool repository
+
+### Completed remainder of governance cleanup
+
+- Removed obsolete legacy workflow files from both `main` and `next`
+- Added ADR `0003-http-surface-governance`
+- Updated dependency review workflow to the supported configuration
+- Restored strict branch governance on both `main` and `next` after controlled
+  PR-based cleanup merges
+- Confirmed both active branches now have the same governed workflow inventory
+- Handed Australian prerelease work off to the tool-side
+  `australian-expansion-next` track

--- a/conductor/tracks/release-governance-modernization/index.md
+++ b/conductor/tracks/release-governance-modernization/index.md
@@ -1,0 +1,45 @@
+# Track: Release Governance Modernization
+
+## Context
+
+- [Specification](./spec.md)
+- [Implementation Plan](./plan.md)
+- [Progress Log](./PROGRESS_LOG.md)
+- [Metadata](./metadata.json)
+
+## Status
+
+🟢 COMPLETE - Governance baseline and follow-on cleanup implemented on both active branches
+
+## Summary
+
+This coordination track modernizes package governance, release automation, and
+repository operating rules for `nz-legislation-tool`.
+
+The baseline governance work has already been implemented in the active tool
+repository:
+
+- canonical `CI`, `Release Stable`, and `Release Next` workflows
+- `main` stable and `next` prerelease branch model
+- npm trusted publishing and GitHub Packages mirror
+- `1.2.0` stable release of the NZ CLI + MCP package
+- maintainer guides, architecture decision records, and package policy docs
+- legacy `master` branch archived rather than deleted
+
+The remaining work is now outside this track:
+
+- future HTTP/OpenAPI surface work is governed by policy and architecture
+  decision records
+- Australian prerelease work is handed off to the tool-side
+  `australian-expansion-next` track
+
+## Outcome
+
+The package now has a governed stable line and a governed prerelease lane. The
+release policy has also been corrected to reflect the actual shipped decision:
+MCP was released as additive `1.2.0`, not as a major `2.0.0`.
+
+---
+
+**Track ID:** `release-governance-modernization`
+**Last Updated:** 2026-03-12

--- a/conductor/tracks/release-governance-modernization/metadata.json
+++ b/conductor/tracks/release-governance-modernization/metadata.json
@@ -1,0 +1,8 @@
+{
+  "track_id": "release-governance-modernization",
+  "type": "feature",
+  "status": "complete",
+  "created_at": "2026-03-11T00:00:00+11:00",
+  "updated_at": "2026-03-12T16:12:01+11:00",
+  "description": "Modernize package governance, release automation, and stable/prerelease operating rules for nz-legislation-tool"
+}

--- a/conductor/tracks/release-governance-modernization/plan.md
+++ b/conductor/tracks/release-governance-modernization/plan.md
@@ -1,0 +1,138 @@
+# Plan: Release Governance Modernization
+
+**Track ID:** release-governance-modernization  
+**Status:** 🟢 COMPLETE  
+**Priority:** 🔴 HIGH  
+**Last Updated:** 2026-03-12
+
+---
+
+## Summary
+
+The governance baseline has been implemented. This plan now serves as a
+coordination record of what is complete, what was corrected after shipping, and
+what remains open.
+
+---
+
+## Phase 1: Canonical Release Topology
+
+### Completed
+
+- [x] Establish `main` as the stable branch
+- [x] Establish `next` as the prerelease branch
+- [x] Define `CI` as the canonical validation workflow
+- [x] Define `Release Stable` as the canonical stable publish workflow
+- [x] Define `Release Next` as the canonical prerelease publish workflow
+- [x] Demote overlapping legacy workflows to fallback/manual status
+- [x] Publish ADR `0001-release-governance-topology`
+
+### Evidence
+
+- `docs/adr/0001-release-governance-topology.md`
+- `.github/workflows/ci.yml`
+- `.github/workflows/release-stable.yml`
+- `.github/workflows/release-next.yml`
+
+---
+
+## Phase 2: Publishing and Registry Governance
+
+### Completed
+
+- [x] Configure npm trusted publishing for stable releases
+- [x] Harden stable release workflow with provenance
+- [x] Harden prerelease workflow for the `next` lane
+- [x] Publish the GitHub Packages mirror
+- [x] Publish `nz-legislation-tool@1.2.0`
+- [x] Create GitHub release `v1.2.0`
+
+### Evidence
+
+- npm package `nz-legislation-tool@1.2.0`
+- GitHub release `v1.2.0`
+- `.github/workflows/release-stable.yml`
+- `.github/workflows/release-next.yml`
+- `.github/workflows/publish-github-packages.yml`
+
+---
+
+## Phase 3: Governance Documents and Contributor Guardrails
+
+### Completed
+
+- [x] Add package release policy
+- [x] Add support policy
+- [x] Add maintainer checklists and hotfix process
+- [x] Add release-aware contributor guidance
+- [x] Clarify package registry policy
+- [x] Clarify CLI vs MCP positioning
+
+### Corrective Work Completed
+
+- [x] Update release policy to reflect the actual `1.2.0` MCP release decision
+- [x] Remove the stale assumption that MCP implied `v2.0.0`
+- [x] Align prerelease language so `next` is treated as a governed lane rather
+      than automatically the next major
+
+### Evidence
+
+- `RELEASE_POLICY.md`
+- `SUPPORT_POLICY.md`
+- `docs/maintainers/release-captain-checklist.md`
+- `docs/maintainers/release-aware-contributor-quickstart.md`
+- `docs/maintainers/hotfix-process.md`
+- `docs/maintainers/australian-release-readiness.md`
+
+---
+
+## Phase 4: Branch History and Legacy Preservation
+
+### Completed
+
+- [x] Review the old `master` branch
+- [x] Determine it is legacy history, not the active release line
+- [x] Preserve it through `archive/legacy-workspace-master`
+- [x] Add ADR `0002-archive-legacy-master-branch`
+
+### Evidence
+
+- `docs/adr/0002-archive-legacy-master-branch.md`
+- remote branch `archive/legacy-workspace-master`
+
+---
+
+## Phase 5: Product vs Research Boundary
+
+### Completed
+
+- [x] Establish product-owned governance docs
+- [x] Separate active tool-side Conductor from research-side Conductor
+- [x] Keep research work out of stable package release policy
+
+### Follow-On Work
+
+- [ ] convert child repositories to true submodules once the parent workspace is
+      no longer contested
+
+---
+
+## Phase 6: Remaining Cleanup
+
+- [x] remove or fully retire legacy manual-only workflows
+- [x] reduce direct admin pushes by tightening branch governance
+- [x] decide how future HTTP/OpenAPI governance enters the stable policy
+- [x] hand Australian prerelease work off to the tool-side
+      `australian-expansion-next` track
+
+---
+
+## Exit Criteria
+
+This track is complete now that:
+
+1. legacy workflow cleanup has been applied on both `main` and `next`
+2. both governed branches enforce review, conversation resolution, and admin
+   protection again after the controlled cleanup merges
+3. forward-looking multi-jurisdiction work is formally handed off to the
+   tool-side Australian track without ambiguity

--- a/conductor/tracks/release-governance-modernization/spec.md
+++ b/conductor/tracks/release-governance-modernization/spec.md
@@ -1,0 +1,77 @@
+# Specification: Release Governance Modernization
+
+## Problem
+
+The project had overlapping workflows, unclear release ownership, ambiguous
+branch semantics, and no durable operating model for the package's multiple
+public surfaces.
+
+It also needed to separate:
+
+- stable package release governance
+- prerelease experimentation
+- product-owned documentation and package policy
+- research-owned work that should not drive product releases
+
+## Scope
+
+This track governs the package and release system for `nz-legislation-tool`.
+
+In scope:
+
+- branch and workflow topology
+- stable and prerelease publication rules
+- SemVer decision policy for CLI, MCP, and future HTTP/OpenAPI surfaces
+- GitHub Packages visibility
+- maintainer guides and architecture decision records
+- product vs research boundary guardrails
+
+Out of scope:
+
+- implementing Australian jurisdiction support itself
+- implementing the future HTTP adapter itself
+- research methodology or publication work
+
+## Required Outcomes
+
+1. A canonical release topology exists and is documented.
+2. Stable publishing works via trusted publishing and provenance.
+3. Prerelease publishing is governed separately from stable.
+4. The package version is the canonical product version.
+5. MCP is treated as a governed public contract.
+6. Product governance is separated from research governance.
+7. The release policy matches actual shipped decisions.
+
+## Acceptance Criteria
+
+- `main` is the stable branch and `next` is the prerelease branch.
+- `CI`, `Release Stable`, and `Release Next` are the canonical workflows.
+- `nz-legislation-tool@1.2.0` is published as the stable MCP-enabled release.
+- A GitHub release exists for `v1.2.0`.
+- Stable publishing uses trusted publishing rather than ad hoc token-only logic.
+- Governance docs exist for maintainers and contributors.
+- The release policy states that MCP shipped as additive `1.2.0`.
+- The archived `master` line is preserved for history and not treated as the
+  live release branch.
+
+## Evidence Sources
+
+Primary evidence lives in the active tool repository and published package:
+
+- `RELEASE_POLICY.md`
+- `SUPPORT_POLICY.md`
+- `docs/adr/0001-release-governance-topology.md`
+- `docs/adr/0002-archive-legacy-master-branch.md`
+- `docs/maintainers/release-captain-checklist.md`
+- `docs/maintainers/release-aware-contributor-quickstart.md`
+- `docs/maintainers/hotfix-process.md`
+- `docs/maintainers/australian-release-readiness.md`
+- `.github/workflows/ci.yml`
+- `.github/workflows/release-stable.yml`
+- `.github/workflows/release-next.yml`
+
+## Follow-On Tracks
+
+This track hands off implementation work for Australian prerelease scope to:
+
+- `nz-legislation-tool/conductor/tracks/australian-expansion-next`


### PR DESCRIPTION
## Summary
- expand the conductor workspace beyond the minimal ANZ planning track
- add archive, backlog, and template indexes plus backlog placeholder metadata
- restore local records for release governance and documentation-site tracks so the workspace inventory is internally coherent

## Validation
- pnpm exec vale conductor