### PR TITLE
docs: complete ANZ transition planning and start ANZ-first copy

### DIFF
--- a/.changeset/tiny-eggs-smell.md
+++ b/.changeset/tiny-eggs-smell.md
@@ -1,0 +1,5 @@
+---
+'nz-legislation-tool': patch
+---
+
+Qualify the initial ANZ branding copy so README and CLI help reflect the current prerelease scope of Australian support, and complete the implementation-ready planning artifacts for the ANZ transition track.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,6 +1,6 @@
-# Contributing to NZ Legislation Tool
+# Contributing to ANZ Legislation
 
-Thank you for your interest in contributing to the NZ Legislation Tool! This document provides guidelines and instructions for contributing to the project.
+Thank you for your interest in contributing to ANZ Legislation. This document provides guidelines and instructions for contributing to the project. The published package and CLI names remain on the legacy `nz-legislation-tool` path during the transition.
 
 ## 🎯 Table of Contents
 
@@ -28,7 +28,7 @@ Please be respectful and constructive in your interactions. We're committed to p
 ### Prerequisites
 
 - **Node.js** 18+ (LTS versions: 18, 20, 22)
-- **pnpm** 9+ (package manager)
+- **`pnpm`** 9+ (package manager)
 - **Git** for version control
 - **GitHub account** for contributing
 
@@ -39,7 +39,7 @@ Please be respectful and constructive in your interactions. We're committed to p
    ```bash
    # Click "Fork" on GitHub, then clone your fork
    git clone https://github.com/YOUR_USERNAME/nz-legislation.git
-   cd nz-legislation-tool
+   cd nz-legislation
    ```
 
 2. **Install dependencies**
@@ -111,7 +111,7 @@ Follow the prompts to:
 
 - Patch: "Fix rate limiting configuration error"
 - Minor: "Add CSV export format for search results"
-- Major: "Change authentication method from query param to header"
+- Major: "Change authentication method from query parameter to header"
 
 ### 3. Commit Your Changes
 
@@ -331,7 +331,7 @@ Update the README.md if you:
 
 ### Code Comments
 
-- Add JSDoc comments for exported functions
+- Add JS doc comments for exported functions
 - Explain complex logic
 - Document parameters and return values
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -331,7 +331,7 @@ Update the README.md if you:
 
 ### Code Comments
 
-- Add JS doc comments for exported functions
+- Add `JSDoc` comments for exported functions
 - Explain complex logic
 - Document parameters and return values
 

--- a/DEVELOPER_GUIDE.md
+++ b/DEVELOPER_GUIDE.md
@@ -1,6 +1,6 @@
 # Developer Guide
 
-Welcome to the NZ Legislation Tool development team! This guide will help you get set up and contributing in under 30 minutes.
+Welcome to the ANZ Legislation development team. This guide will help you get set up and contributing in under 30 minutes. The repo is transitioning in public branding, but the package and CLI names remain on the current `nz-legislation-tool` path for compatibility.
 
 ## 🚀 Quick Start (5 minutes)
 
@@ -15,7 +15,7 @@ Welcome to the NZ Legislation Tool development team! This guide will help you ge
 ```bash
 # Clone the repository
 git clone https://github.com/edithatogo/nz-legislation.git
-cd nz-legislation-tool
+cd nz-legislation
 
 # Install dependencies
 npm install
@@ -288,7 +288,7 @@ describe('ComponentName', () => {
 
 - **Unit Tests**: Test individual functions/modules
 - **Integration Tests**: Test API interactions (MSW mocked)
-- **E2E Tests**: Test full CLI commands (execa)
+- **E2E Tests**: Test full CLI commands (command-runner integration)
 - **Property Tests**: Test invariants with fast-check
 - **Hypothesis Tests**: Test consistency/reproducibility
 

--- a/DEVELOPER_GUIDE.md
+++ b/DEVELOPER_GUIDE.md
@@ -288,7 +288,7 @@ describe('ComponentName', () => {
 
 - **Unit Tests**: Test individual functions/modules
 - **Integration Tests**: Test API interactions (MSW mocked)
-- **E2E Tests**: Test full CLI commands (command-runner integration)
+- **E2E Tests**: Test full CLI commands (`execa`)
 - **Property Tests**: Test invariants with fast-check
 - **Hypothesis Tests**: Test consistency/reproducibility
 

--- a/README.md
+++ b/README.md
@@ -7,9 +7,9 @@
 [![CI/CD](https://github.com/edithatogo/nz-legislation/actions/workflows/ci.yml/badge.svg)](https://github.com/edithatogo/nz-legislation/actions/workflows/ci.yml)
 [![Maintenance](https://img.shields.io/badge/Maintained%3F-yes-green.svg)](https://github.com/edithatogo/nz-legislation/graphs/commit-activity)
 
-**Search, retrieve, and cite legislation across New Zealand and Australia.**
+**Search, retrieve, and cite New Zealand legislation, with Australian support now in prerelease.**
 
-A fast, friendly command-line tool for researchers, legal professionals, and anyone working with legislation across New Zealand and Australia. Get your research done faster with less copying and pasting.
+A fast, friendly command-line tool for researchers, legal professionals, and anyone working with legislation across New Zealand and Australia. New Zealand support remains the most complete path today, while Australian providers are being rolled out in staged prerelease form. Get your research done faster with less copying and pasting.
 
 The product is now presented publicly as **ANZ Legislation**. The published npm package and CLI commands remain `nz-legislation-tool`, `nzlegislation`, and `nzlegislation-mcp` for compatibility during the transition.
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# NZ Legislation Tool
+# ANZ Legislation
 
 [![npm](https://img.shields.io/npm/v/nz-legislation-tool)](https://www.npmjs.com/package/nz-legislation-tool)
 [![npm](https://img.shields.io/npm/dm/nz-legislation-tool)](https://www.npmjs.com/package/nz-legislation-tool)
@@ -7,9 +7,11 @@
 [![CI/CD](https://github.com/edithatogo/nz-legislation/actions/workflows/ci.yml/badge.svg)](https://github.com/edithatogo/nz-legislation/actions/workflows/ci.yml)
 [![Maintenance](https://img.shields.io/badge/Maintained%3F-yes-green.svg)](https://github.com/edithatogo/nz-legislation/graphs/commit-activity)
 
-**Search, retrieve, and cite New Zealand legislation in seconds.**
+**Search, retrieve, and cite legislation across New Zealand and Australia.**
 
-A fast, friendly command-line tool for researchers, legal professionals, and anyone working with NZ legislation. Get your research done faster—with less copying and pasting.
+A fast, friendly command-line tool for researchers, legal professionals, and anyone working with legislation across New Zealand and Australia. Get your research done faster with less copying and pasting.
+
+The product is now presented publicly as **ANZ Legislation**. The published npm package and CLI commands remain `nz-legislation-tool`, `nzlegislation`, and `nzlegislation-mcp` for compatibility during the transition.
 
 **Package links:** [npm package](https://www.npmjs.com/package/nz-legislation-tool) · [GitHub repository](https://github.com/edithatogo/nz-legislation)
 
@@ -511,8 +513,8 @@ npx nz-legislation-tool search --query "health"
 ### Option 3: From Source (For contributors)
 
 ```bash
-git clone https://github.com/edithatogo/nz-legislation-tool
-cd nz-legislation-tool
+git clone https://github.com/edithatogo/nz-legislation
+cd nz-legislation
 npm install
 npm run build
 npm link  # Install globally
@@ -540,8 +542,8 @@ See [CONTRIBUTING.md](CONTRIBUTING.md) for how to get started.
 
 ```bash
 # Clone the repo
-git clone https://github.com/edithatogo/nz-legislation-tool
-cd nz-legislation-tool
+git clone https://github.com/edithatogo/nz-legislation
+cd nz-legislation
 
 # Install dependencies
 npm install
@@ -598,8 +600,8 @@ See [MAINTENANCE_GUIDE.md](MAINTENANCE_GUIDE.md) for details.
 
 Need help? We're here for you.
 
-- 🐛 **Found a bug?** [Open an issue](https://github.com/edithatogo/nz-legislation-tool/issues)
-- 💬 **Have a question?** [Start a discussion](https://github.com/edithatogo/nz-legislation-tool/discussions)
+- 🐛 **Found a bug?** [Open an issue](https://github.com/edithatogo/nz-legislation/issues)
+- 💬 **Have a question?** [Start a discussion](https://github.com/edithatogo/nz-legislation/discussions)
 - 📧 **Email:** dylan.mordaunt@vuw.ac.nz
 - 📖 **API docs:** https://api.legislation.govt.nz/docs/
 
@@ -617,7 +619,7 @@ Apache License 2.0 - See [LICENSE](LICENSE) for details.
 
 <div align="center">
 
-**Built with ❤️ for New Zealand researchers, by researchers.**
+**Built for legislation research across New Zealand and Australia.**
 
 [npm](https://www.npmjs.com/package/nz-legislation-tool) ·
 [GitHub](https://github.com/edithatogo/nz-legislation) ·

--- a/conductor/status.md
+++ b/conductor/status.md
@@ -13,19 +13,29 @@ See also:
 
 ## Active Track Inventory
 
-| Track                  | Status  | Notes                                   |
-| ---------------------- | ------- | --------------------------------------- |
-| `anz-brand-transition` | PENDING | Staged rename plan for product and repo |
+| Track                  | Status | Notes                                                       |
+| ---------------------- | ------ | ----------------------------------------------------------- |
+| `anz-brand-transition` | ACTIVE | Planning complete; implementation and rollout work now next |
 
 ## Current Read on Project State
 
 - The repository now has an explicit Conductor track for ANZ rename planning.
-- The product still ships as `nz-legislation-tool` and has not begun the rename
-  implementation yet.
-- The active tracked work here is planning and migration governance, not the
-  rename itself.
+- Phase 1 is complete: target names, compatibility window, and canonical versus
+  legacy public surfaces are now documented.
+- Phase 2 is complete: rename-sensitive surfaces, dual-branding rules, and safe
+  early-edit boundaries are now documented.
+- Phase 3 is complete: package migration, CLI aliasing, and deprecation
+  messaging now have a chosen strategy.
+- Phase 4 is complete: repository, docs, site, MCP, and support-link migration
+  points now have an explicit checklist.
+- Phase 5 is complete: deprecation criteria, legacy retirement order, and track
+  closure conditions are now defined.
+- The product still ships as `nz-legislation-tool`, and package or binary
+  renaming has not started yet.
+- Planning is complete. The active tracked work here is now implementation and
+  rollout against the approved ANZ transition artifacts.
 
 ## Recommended Next Step
 
-1. Complete Phase 1 naming-policy decisions for `anz-brand-transition`.
-2. Use the phase review gate before moving into implementation work.
+1. Start implementation with the first operational PR: safe ANZ-first product-copy edits that do not rename package, CLI, MCP, env vars, or config paths.
+2. After that, execute the package/CLI migration and repo/docs migration in reviewed rollout phases rather than further planning-only edits.

--- a/conductor/status.md
+++ b/conductor/status.md
@@ -62,7 +62,7 @@ detail under `research-conductor` instead of this product-side Conductor tree.
 
 1. Start ANZ transition implementation with reviewed operational PRs, beginning
    with safe ANZ-first product-copy edits that do not rename package, CLI, MCP,
-   env vars, or config paths.
+   environment variables, or config paths.
 2. Track future status changes by updating `metadata.json` alongside each
    active track’s `index.md` and `plan.md`.
 3. Promote backlog entries back into `conductor/tracks` only when they gain a

--- a/conductor/tracks/anz-brand-transition/decision.md
+++ b/conductor/tracks/anz-brand-transition/decision.md
@@ -1,0 +1,57 @@
+# Phase 1 Decision Record: Naming and Compatibility Policy
+
+**Track ID:** `anz-brand-transition`  
+**Phase:** `1`  
+**Approved:** `2026-03-14`
+
+## Approved Names
+
+- Product name: `ANZ Legislation`
+- Repository target: `anz-legislation`
+- Preferred future npm package: `anz-legislation`
+- Preferred future CLI binaries: `anzlegislation` and `anzlegislation-mcp`
+- Preferred future MCP server name: `anz-legislation`
+
+## Canonical vs Legacy Surface Policy
+
+| Surface           | Current canonical state                   | Future canonical state                            | Phase 1 decision                                                                                |
+| ----------------- | ----------------------------------------- | ------------------------------------------------- | ----------------------------------------------------------------------------------------------- |
+| Product copy      | `NZ Legislation Tool` in many public docs | `ANZ Legislation`                                 | Public-facing copy may begin moving to `ANZ Legislation` before package and binary renames ship |
+| GitHub repository | `edithatogo/nz-legislation`               | `edithatogo/anz-legislation`                      | Repository rename is approved in principle, but deferred to Phase 4                             |
+| npm package       | `nz-legislation-tool`                     | `anz-legislation`                                 | `nz-legislation-tool` remains canonical until a dual-publish or migration path exists           |
+| CLI binaries      | `nzlegislation`, `nzlegislation-mcp`      | `anzlegislation`, `anzlegislation-mcp`            | Existing binaries remain canonical until alias support ships                                    |
+| MCP metadata      | `nz-legislation`                          | `anz-legislation`                                 | MCP rename is deferred until repo/docs/package strategy is coordinated                          |
+| Local config path | `.nz-legislation-tool`                    | `.anz-legislation` or equivalent alias-aware path | Old config path must remain readable throughout the compatibility window                        |
+
+## Compatibility Window
+
+The compatibility window begins when a replacement public surface is first
+shipped to users.
+
+- Minimum duration: `90 days`
+- Minimum release count: `2 minor releases`
+- Old names must remain functional during that full window
+- Old names must be documented as legacy aliases, not silently dropped
+- Removal requires release notes, migration examples, and a passed Phase 5
+  Conductor review
+
+## Explicit Exceptions
+
+- Public documentation may describe the product as `ANZ Legislation` before the
+  npm package and CLI binary names change, but install commands must keep using
+  the current package and binary names until replacements exist.
+- The GitHub repository may be renamed before the npm package is renamed, as
+  long as badges, docs links, workflow references, and support links are
+  updated in the same migration phase.
+- Local config and log handling must prefer backwards compatibility over naming
+  purity during the transition.
+
+## Phase 2 Entry Criteria
+
+Phase 2 can begin now that:
+
+- the target public names are approved
+- the compatibility window is explicit rather than implied
+- canonical versus legacy public surfaces are documented
+- deferred decisions are identified for package, CLI, MCP, and local config
+  migration

--- a/conductor/tracks/anz-brand-transition/deprecation-plan.md
+++ b/conductor/tracks/anz-brand-transition/deprecation-plan.md
@@ -1,0 +1,56 @@
+# Phase 5 Plan: Deprecation and Legacy Cleanup
+
+**Track ID:** `anz-brand-transition`  
+**Phase:** `5`  
+**Approved:** `2026-03-14`
+
+## Deprecation Window End Criteria
+
+Legacy names may only be retired after all of the following are true:
+
+- `anz-legislation` has been publicly shipped
+- `anzlegislation` and `anzlegislation-mcp` have been publicly shipped
+- the compatibility window has lasted at least `90 days`
+- the compatibility window has covered at least `2 minor releases`
+- docs and support materials include exact migration commands
+- local config and environment-variable compatibility has been verified
+
+## Legacy Surface Retirement Order
+
+1. stop presenting old names as preferred defaults in docs
+2. keep old package and binary names functional but clearly labeled legacy
+3. after the window, decide whether `nz-legislation-tool` becomes a shim,
+   remains supported longer, or is retired
+4. only then consider retirement of:
+   - `nzlegislation`
+   - `nzlegislation-mcp`
+   - MCP legacy naming
+   - legacy config-path naming where safe fallback exists
+
+## Final Cleanup Checklist
+
+- remove or archive stale docs that reference the pre-ANZ repo path
+- remove obsolete badges and support links that point to retired names
+- update maintainer docs so the canonical identity is only `ANZ Legislation`
+- confirm release automation, issue templates, and support tooling no longer
+  imply NZ-only branding where that is no longer true
+- verify the old names are either intentionally supported or intentionally
+  retired, with no accidental half-state
+
+## Track Closure Standard
+
+The ANZ brand transition track can be marked complete only when:
+
+- the repository identity has actually moved to `anz-legislation`
+- package and CLI migration has been executed, not just planned
+- repo/docs/site/MCP updates are live
+- deprecation messaging has been published
+- the compatibility window has been honored
+- legacy cleanup decisions have been executed and verified
+
+## Implementation Handover
+
+This planning track is complete in governance terms once implementation begins
+against these approved artifacts. Actual rename work should proceed through
+reviewed PRs and release steps rather than by editing the planning documents
+further unless decisions change.

--- a/conductor/tracks/anz-brand-transition/index.md
+++ b/conductor/tracks/anz-brand-transition/index.md
@@ -15,7 +15,7 @@
 ## Status
 
 🟡 IN PROGRESS - Planning phases are complete; the track is now ready to move
-from planning into implementation and rollout work
+from planning into implementation and roll-out work
 
 ## Summary
 

--- a/conductor/tracks/anz-brand-transition/index.md
+++ b/conductor/tracks/anz-brand-transition/index.md
@@ -4,12 +4,18 @@
 
 - [Specification](./spec.md)
 - [Implementation Plan](./plan.md)
+- [Phase 1 Decision Record](./decision.md)
+- [Phase 2 Surface Inventory](./inventory.md)
+- [Phase 2 Implementation Rules](./rules.md)
+- [Phase 3 Package and CLI Strategy](./package-cli-strategy.md)
+- [Phase 4 Repo and Docs Migration Checklist](./repo-docs-migration.md)
+- [Phase 5 Deprecation Plan](./deprecation-plan.md)
 - [Metadata](./metadata.json)
 
 ## Status
 
-🟡 PENDING - Track created to govern the rename from NZ-only branding to an
-ANZ-wide product identity
+🟡 IN PROGRESS - Planning phases are complete; the track is now ready to move
+from planning into implementation and rollout work
 
 ## Summary
 
@@ -23,6 +29,15 @@ This track treats `anz-legislation` as the target repository name and `ANZ
 Legislation` as the target product identity. It deliberately separates the
 decision, compatibility policy, public-surface migration, and eventual cleanup
 so the transition can happen without breaking current users.
+
+All planning phases are complete. The naming policy is recorded in `decision.md`, the
+rename-sensitive inventory is in `inventory.md`, the dual-branding rules are in
+`rules.md`, and the package/CLI migration strategy is in
+`package-cli-strategy.md`. The repository, documentation, site, MCP, and
+support-link migration checklist is in `repo-docs-migration.md`, and the
+deprecation completion criteria are in `deprecation-plan.md`. The next step is
+no longer planning. It is implementation: execute the rename in reversible
+phases against these approved track artifacts.
 
 ## Intended Outcome
 

--- a/conductor/tracks/anz-brand-transition/inventory.md
+++ b/conductor/tracks/anz-brand-transition/inventory.md
@@ -1,0 +1,107 @@
+# Phase 2 Inventory: Rename-Sensitive Surfaces
+
+**Track ID:** `anz-brand-transition`  
+**Phase:** `2`  
+**Captured:** `2026-03-14`
+
+## Summary
+
+The repository still contains a wide spread of NZ-only naming across package
+metadata, runtime identifiers, documentation, support links, and historical
+release material.
+
+The key Phase 2 conclusion is that public-facing copy can move earlier than
+package, binary, MCP, environment-variable, and config-path names. Those latter
+surfaces are embedded deeply enough that they need explicit compatibility
+handling rather than a blind string replacement.
+
+## Canonical Rename-Sensitive Surface Groups
+
+### Package and Repository Metadata
+
+- `package.json`
+  - package name is `nz-legislation-tool`
+  - repository URL is `edithatogo/nz-legislation`
+  - bugs/homepage fields still point to the old repo path
+  - CLI binaries are `nzlegislation` and `nzlegislation-mcp`
+- `CHANGELOG.md`
+  - title still uses `nz-legislation-tool`
+- `CHANGESETS.md`
+  - GitHub changelog repo still targets `edithatogo/nz-legislation`
+
+### Runtime and Protocol Surfaces
+
+- `src/config.ts`
+  - `Conf` project name is `nz-legislation-tool`
+  - comments and effective config path still assume `.nz-legislation-tool`
+- `src/mcp/server.ts`
+  - MCP server name is `nz-legislation`
+  - startup banner still prints `NZ Legislation MCP Server`
+- `src/client.ts`
+  - error messaging still references the current env var
+  - HTTP user agent still sends `nz-legislation-tool/1.0.0`
+- `src/utils/api-optimization.ts`
+  - user agent still sends `nz-legislation-tool/1.0.0`
+- `src/cli.ts`
+  - help/support output still points to an older repo URL and NZ-only copy
+- `src/commands/generate.ts`
+  - support links still reference the older `dylanmordaunt/nz-legislation-tool` repo
+
+### Legacy Compatibility Surfaces That Must Not Change Early
+
+- CLI binaries
+  - `nzlegislation`
+  - `nzlegislation-mcp`
+- npm package install path
+  - `nz-legislation-tool`
+- environment variable
+  - `NZ_LEGISLATION_API_KEY`
+- local config and log path
+  - `.nz-legislation-tool`
+
+These remain compatibility-critical and should be preserved until the package
+and CLI migration strategy is implemented.
+
+### Public Documentation Surfaces
+
+- `README.md`
+  - package badges, package links, install commands, clone commands, issue links,
+    and support links still point to NZ-only names
+- `docs/user-guide/`
+  - user-facing install and support docs still use `nz-legislation-tool` and
+    `nzlegislation`
+- `docs/developer-guide/`
+  - contributor setup, repo URLs, config paths, and architecture docs still use
+    NZ-only names
+- `docs/documentation-site-config.md`
+  - Docusaurus config examples still use `nz-legislation-tool` for base URL,
+    project name, GitHub links, and Algolia index naming
+- `docs/documentation-site-setup.md`
+  - site setup guidance still assumes `nz-legislation-tool` repo and docs paths
+
+### Workflow, Templates, and Historical Operational Docs
+
+- `.github/ISSUE_TEMPLATE/bug-report.yml`
+  - version prompt still refers to `nz-legislation-tool`
+- `AUTO_PUBLISH.md`
+  - contains an older release path that assumes `nz-legislation` or
+    `nz-legislation-tool` in multiple combinations and will need deliberate
+    cleanup rather than search-replace
+- `CONTRIBUTING.md`, `DEVELOPER_GUIDE.md`
+  - clone paths and support links still reflect pre-ANZ naming
+
+## Initial Phase 2 Implementation Rules
+
+- Product-copy surfaces can become `ANZ Legislation` first.
+- Package name, binary names, MCP name, env vars, and config paths stay legacy
+  until alias or migration support exists.
+- Repo-link cleanup should prefer `edithatogo/nz-legislation` until the actual
+  GitHub rename happens, even if product copy becomes ANZ-first.
+- Historical release and operational documents should be triaged rather than
+  blindly rewritten, because some reflect past states rather than current
+  canonical guidance.
+
+## Immediate Next Step
+
+Use this inventory to decide which internal references can become ANZ-neutral in
+Phase 2 without breaking installs, configs, MCP integrations, or automation.

--- a/conductor/tracks/anz-brand-transition/inventory.md
+++ b/conductor/tracks/anz-brand-transition/inventory.md
@@ -38,7 +38,7 @@ handling rather than a blind string replacement.
   - MCP server name is `nz-legislation`
   - startup banner still prints `NZ Legislation MCP Server`
 - `src/client.ts`
-  - error messaging still references the current env var
+  - error messaging still references the current environment variable
   - HTTP user agent still sends `nz-legislation-tool/1.0.0`
 - `src/utils/api-optimization.ts`
   - user agent still sends `nz-legislation-tool/1.0.0`
@@ -93,15 +93,17 @@ and CLI migration strategy is implemented.
 ## Initial Phase 2 Implementation Rules
 
 - Product-copy surfaces can become `ANZ Legislation` first.
-- Package name, binary names, MCP name, env vars, and config paths stay legacy
+- Package name, binary names, MCP name, environment variables, and config
+  paths stay legacy
   until alias or migration support exists.
 - Repo-link cleanup should prefer `edithatogo/nz-legislation` until the actual
   GitHub rename happens, even if product copy becomes ANZ-first.
-- Historical release and operational documents should be triaged rather than
+- Historical release and operational documents should be reviewed rather than
   blindly rewritten, because some reflect past states rather than current
   canonical guidance.
 
 ## Immediate Next Step
 
 Use this inventory to decide which internal references can become ANZ-neutral in
-Phase 2 without breaking installs, configs, MCP integrations, or automation.
+Phase 2 without breaking installs, configurations, MCP integrations, or
+automation.

--- a/conductor/tracks/anz-brand-transition/metadata.json
+++ b/conductor/tracks/anz-brand-transition/metadata.json
@@ -1,8 +1,10 @@
 {
   "track_id": "anz-brand-transition",
   "type": "feature",
-  "status": "pending",
+  "status": "in_progress",
   "created_at": "2026-03-14T11:00:00+11:00",
-  "updated_at": "2026-03-14T11:00:00+11:00",
+  "updated_at": "2026-03-14T14:35:00+11:00",
+  "current_phase": "implementation_ready",
+  "planning_complete": true,
   "description": "Plan and execute the staged product, package, repository, and documentation transition from NZ-only branding to ANZ branding"
 }

--- a/conductor/tracks/anz-brand-transition/package-cli-strategy.md
+++ b/conductor/tracks/anz-brand-transition/package-cli-strategy.md
@@ -1,0 +1,113 @@
+# Phase 3 Strategy: Package and CLI Migration
+
+**Track ID:** `anz-brand-transition`  
+**Phase:** `3`  
+**Approved:** `2026-03-14`
+
+## Registry Findings
+
+- Current public npm package: `nz-legislation-tool@1.2.0`
+- Current public dist-tag: `latest`
+- Proposed future package `anz-legislation` is currently available on npm
+- Scoped mirror package `@edithatogo/nz-legislation-tool` is not publicly
+  installed from npmjs.com and should not be treated as the main migration path
+
+## Chosen Strategy
+
+### Package Strategy
+
+Use **dual-publish**, not a pure shim package.
+
+The recommended path is:
+
+1. keep publishing `nz-legislation-tool`
+2. introduce `anz-legislation` as a sibling package carrying the same release
+   line
+3. keep both packages functionally supported through the compatibility window
+4. only after the compatibility window, decide whether `nz-legislation-tool`
+   becomes a shim, remains supported longer, or is retired
+
+### Why Not a Pure Shim First
+
+A pure shim package is the wrong first move because:
+
+- globally installed CLI binaries need to work directly
+- npm dependency bins are not a clean user-facing replacement for global
+  installs
+- a shim complicates support and troubleshooting before the ANZ names are even
+  established in the field
+
+The least confusing user experience is to publish a real sibling package with
+its own direct binaries.
+
+## CLI Strategy
+
+Introduce new binaries while preserving the old ones:
+
+- legacy binaries remain supported:
+  - `nzlegislation`
+  - `nzlegislation-mcp`
+- future binaries are introduced:
+  - `anzlegislation`
+  - `anzlegislation-mcp`
+
+The first release that introduces `anz-legislation` should make the new binary
+names available without removing the old ones.
+
+## Release Sequencing
+
+### First ANZ Migration Release
+
+- package `nz-legislation-tool` still published
+- package `anz-legislation` published for the first time
+- release notes present `ANZ Legislation` as the product identity
+- old install path remains documented as supported
+- new install path is added as the preferred forward-looking path
+
+### Compatibility Window Releases
+
+- both package names remain supported
+- both CLI naming paths remain documented
+- support docs explicitly label `nz-legislation-tool` and `nzlegislation*` as
+  legacy-compatible paths
+
+### Post-Window Decision Point
+
+At the end of the window, choose one of:
+
+- retire `nz-legislation-tool`
+- convert `nz-legislation-tool` into a shim
+- extend dual-publish if migration uptake is too low
+
+## Release-Note Messaging
+
+The first ANZ migration release should say:
+
+- the product is now presented publicly as `ANZ Legislation`
+- existing users can continue using `nz-legislation-tool` and
+  `nzlegislation*`
+- new users may install `anz-legislation` and use `anzlegislation*`
+- the old names are legacy-compatible and will remain supported for at least
+  `90 days` and `2 minor releases`
+
+## Deprecation Messaging
+
+Deprecation messaging must begin when the new package and binaries actually
+ship, not earlier.
+
+Required message shape:
+
+- "supported legacy path" rather than "obsolete"
+- exact migration commands
+- end-of-window criteria
+- confirmation that local config and existing env vars still work
+
+## Phase 4 Handover
+
+Phase 4 can now plan the repository and docs migration with the following
+assumption:
+
+- product copy can be ANZ-first
+- repo rename can happen before legacy package removal
+- package and CLI migration no longer block repo/docs planning because the
+  compatibility path is defined

--- a/conductor/tracks/anz-brand-transition/package-cli-strategy.md
+++ b/conductor/tracks/anz-brand-transition/package-cli-strategy.md
@@ -100,7 +100,7 @@ Required message shape:
 - "supported legacy path" rather than "obsolete"
 - exact migration commands
 - end-of-window criteria
-- confirmation that local config and existing env vars still work
+- confirmation that local config and existing environment variables still work
 
 ## Phase 4 Handover
 

--- a/conductor/tracks/anz-brand-transition/plan.md
+++ b/conductor/tracks/anz-brand-transition/plan.md
@@ -1,7 +1,7 @@
 # Plan: ANZ Brand Transition
 
 **Track ID:** anz-brand-transition  
-**Status:** 🟡 PENDING  
+**Status:** 🟡 IN PROGRESS  
 **Priority:** 🔴 HIGH  
 **Last Updated:** 2026-03-14
 
@@ -31,11 +31,20 @@ package, CLI, documentation, or MCP install base.
 - deprecation policy for old package and binary names
 - canonical list of renamed versus preserved public surfaces
 
+### Phase 1 Decision Outcome
+
+- `ANZ Legislation` is approved as the target public product name
+- `anz-legislation` is approved as the target repository name
+- the compatibility window is defined as at least `90 days` and `2 minor releases`
+- the current npm package, CLI binaries, MCP name, and local config path remain
+  canonical until explicit migration support exists
+- the approved decision record lives in `decision.md`
+
 ### Automated Review Gate
 
-- [ ] Run `node scripts/conductor-phase-review.mjs --track anz-brand-transition --phase 1`
-- [ ] Update `index.md`, `plan.md`, and `metadata.json` with the approved naming policy
-- [ ] Record any explicit exceptions before Phase 2 starts
+- [x] Run `node scripts/conductor-phase-review.mjs --track anz-brand-transition --phase 1`
+- [x] Update `index.md`, `plan.md`, and `metadata.json` with the approved naming policy
+- [x] Record any explicit exceptions before Phase 2 starts
 
 ---
 
@@ -53,11 +62,23 @@ package, CLI, documentation, or MCP install base.
 - implementation rules for dual-branding and alias support
 - updated internal references that should stop assuming NZ-only branding
 
+### Phase 2 Progress Note
+
+- initial inventory captured in `inventory.md`
+- package metadata, runtime identifiers, docs, and support links all contain
+  NZ-only naming
+- compatibility-critical legacy surfaces are now explicitly separated from
+  copy-first rename candidates
+- concrete dual-branding rules and safe early-edit boundaries are recorded in
+  `rules.md`
+- Phase 2 concludes that product copy can lead, but install/runtime identifiers
+  must lag until explicit alias or migration support exists
+
 ### Automated Review Gate
 
-- [ ] Run `node scripts/conductor-phase-review.mjs --track anz-brand-transition --phase 2`
-- [ ] Update track artifacts with the internal migration inventory
-- [ ] Confirm the remaining public rename work is sequenced and reversible
+- [x] Run `node scripts/conductor-phase-review.mjs --track anz-brand-transition --phase 2`
+- [x] Update track artifacts with the internal migration inventory
+- [x] Confirm the remaining public rename work is sequenced and reversible
 
 ---
 
@@ -75,6 +96,16 @@ package, CLI, documentation, or MCP install base.
 - CLI alias strategy
 - release-note and deprecation messaging for current users
 
+### Phase 3 Decision Outcome
+
+- `anz-legislation` is available on npm and can be reserved as the future
+  sibling package
+- dual-publish is approved over a pure shim-first approach
+- legacy CLI binaries remain supported while `anzlegislation*` binaries are
+  introduced
+- release-note and deprecation messaging are defined in
+  `package-cli-strategy.md`
+
 ### Constraints
 
 - no breaking CLI rename without a published compatibility window
@@ -82,9 +113,9 @@ package, CLI, documentation, or MCP install base.
 
 ### Automated Review Gate
 
-- [ ] Run `node scripts/conductor-phase-review.mjs --track anz-brand-transition --phase 3`
-- [ ] Update track artifacts with the chosen package and CLI migration strategy
-- [ ] Verify the plan still preserves a working path for existing users
+- [x] Run `node scripts/conductor-phase-review.mjs --track anz-brand-transition --phase 3`
+- [x] Update track artifacts with the chosen package and CLI migration strategy
+- [x] Verify the plan still preserves a working path for existing users
 
 ---
 
@@ -102,6 +133,14 @@ package, CLI, documentation, or MCP install base.
 - docs/site migration checklist
 - MCP metadata and support-link migration checklist
 
+### Phase 4 Decision Outcome
+
+- the repository rename prerequisites and branch-protection checks are captured
+  in `repo-docs-migration.md`
+- docs, site, MCP, and support-link migration points are explicitly named
+- the repo rename is sequenced with docs/site cleanup rather than treated as an
+  isolated operation
+
 ### Constraints
 
 - GitHub Pages path changes must be coordinated with documentation deployment
@@ -109,9 +148,9 @@ package, CLI, documentation, or MCP install base.
 
 ### Automated Review Gate
 
-- [ ] Run `node scripts/conductor-phase-review.mjs --track anz-brand-transition --phase 4`
-- [ ] Update track artifacts with the repository and docs migration outcome
-- [ ] Confirm no critical public links remain on the old repo path without redirects
+- [x] Run `node scripts/conductor-phase-review.mjs --track anz-brand-transition --phase 4`
+- [x] Update track artifacts with the repository and docs migration outcome
+- [x] Confirm no critical public links remain on the old repo path without redirects
 
 ---
 
@@ -129,19 +168,28 @@ package, CLI, documentation, or MCP install base.
 - final cleanup list for old names in code, docs, workflows, and support materials
 - closure criteria for the transition track
 
+### Phase 5 Decision Outcome
+
+- the compatibility-window end criteria are defined in `deprecation-plan.md`
+- the retirement order for legacy names is now sequenced
+- the transition track closure standard is explicit
+- planning is complete and the next work should be implementation, not more
+  naming-policy design
+
 ### Automated Review Gate
 
-- [ ] Run `node scripts/conductor-phase-review.mjs --track anz-brand-transition --phase 5`
-- [ ] Update track artifacts with final deprecation decisions
-- [ ] Confirm whether the track can be marked complete or needs a follow-on cleanup track
+- [x] Run `node scripts/conductor-phase-review.mjs --track anz-brand-transition --phase 5`
+- [x] Update track artifacts with final deprecation decisions
+- [x] Confirm whether the track can be marked complete or needs a follow-on cleanup track
 
 ---
 
 ## Immediate Recommendation
 
-Proceed with `ANZ Legislation` and `anz-legislation` as the target public names,
-but do not rename the npm package or CLI binaries in the same step as the repo
-rename. The least risky order is:
+Phases 1 and 2 are complete. The next step is still to proceed with
+`ANZ Legislation` and `anz-legislation` as the target public names, but not to
+rename the npm package or CLI binaries in the same step as the repo rename. The
+least risky order remains:
 
 1. agree naming policy
 2. prepare dual-branding internally

--- a/conductor/tracks/anz-brand-transition/repo-docs-migration.md
+++ b/conductor/tracks/anz-brand-transition/repo-docs-migration.md
@@ -1,0 +1,89 @@
+# Phase 4 Checklist: Repository, Documentation, and Site Migration
+
+**Track ID:** `anz-brand-transition`  
+**Phase:** `4`  
+**Approved:** `2026-03-14`
+
+## Repository Rename Checklist
+
+- rename GitHub repository from `edithatogo/nz-legislation` to
+  `edithatogo/anz-legislation`
+- verify branch protection survives the rename on `next`
+- re-check required status checks after rename:
+  - `Typecheck`
+  - `Test (Node 18)`
+  - `Test (Node 20)`
+  - `Test (Node 22)`
+  - `Require changeset for user-facing changes`
+- preserve required review count of `1`
+- preserve required conversation resolution and linear history
+- verify issue, discussion, release, and Actions redirects work
+
+## Docs and Site Migration Checklist
+
+### Repository Links
+
+Update current docs and support links that still point to:
+
+- `edithatogo/nz-legislation-tool`
+- `dylanmordaunt/nz-legislation-tool`
+- older GitHub Pages paths derived from `nz-legislation-tool`
+
+### README and Core Entry Docs
+
+- `README.md`
+  - badges
+  - repository links
+  - clone commands
+  - issue/discussion/support links
+- `CONTRIBUTING.md`
+- `DEVELOPER_GUIDE.md`
+
+### Documentation Site Material
+
+- `docs/documentation-site-config.md`
+  - `baseUrl`
+  - `projectName`
+  - edit URLs
+  - social/support links
+  - search index naming
+- `docs/documentation-site-setup.md`
+  - site URL examples
+  - edit URLs
+  - GitHub links
+  - historical platform examples that mention `nz-legislation-tool`
+
+### User and Developer Guides
+
+- `docs/user-guide/`
+  - issue/discussion/support links
+  - accessibility/support references
+- `docs/developer-guide/`
+  - clone paths
+  - upstream remote examples
+  - issue/discussion links
+
+## MCP and Support-Link Checklist
+
+- update `src/mcp/server.ts` name field only when the coordinated rename release
+  is ready
+- update MCP startup banner after package and docs coordination is ready
+- update support links in `src/cli.ts` and `src/commands/generate.ts`
+- ensure support links point to the actual current repo at each migration stage
+
+## Sequencing Rules
+
+- repo rename and docs-link cleanup should happen in the same phase
+- GitHub Pages path changes must be bundled with docs-site config updates
+- MCP metadata rename should not precede repo/docs coordination
+- package and CLI legacy names remain supported even after the repo rename
+
+## Completion Standard
+
+Phase 4 is considered planned and sequenced when:
+
+- the repo rename prerequisites are explicit
+- the docs/site files needing updates are named
+- MCP and support-link migration points are identified
+- no critical public surface is assumed to update automatically without
+  verification

--- a/conductor/tracks/anz-brand-transition/rules.md
+++ b/conductor/tracks/anz-brand-transition/rules.md
@@ -1,0 +1,101 @@
+# Phase 2 Rules: Dual-Branding and Safe Early Edits
+
+**Track ID:** `anz-brand-transition`  
+**Phase:** `2`  
+**Approved:** `2026-03-14`
+
+## Purpose
+
+These rules convert the raw Phase 2 inventory into implementation constraints
+for future rename work. They define what can safely become ANZ-neutral early,
+what must remain legacy until compatibility support exists, and how mixed-brand
+states should be described to users.
+
+## Dual-Branding Rules
+
+### Rule 1: Product Copy Can Lead
+
+User-facing descriptive copy may move from `NZ Legislation Tool` to
+`ANZ Legislation` before package, CLI, MCP, repository, or config names change.
+
+Examples:
+
+- README headings and descriptive blurbs
+- docs introductions and overview pages
+- feature descriptions and support language
+
+### Rule 2: Install and Invocation Paths Must Lag
+
+Install commands and executable examples must keep using the currently
+functional legacy names until replacement paths are shipped.
+
+Keep legacy names for now:
+
+- `npm install -g nz-legislation-tool`
+- `npx nz-legislation-tool ...`
+- `nzlegislation`
+- `nzlegislation-mcp`
+
+### Rule 3: Runtime Identifiers Need Explicit Migration Support
+
+Do not rename these surfaces in-place without alias or fallback handling:
+
+- npm package name
+- CLI binary names
+- MCP server name
+- local config/log directory name
+- HTTP user agent identifier
+- environment variable names such as `NZ_LEGISLATION_API_KEY`
+
+### Rule 4: Repo Links Must Match Actual GitHub Reality
+
+Do not rewrite repository links to `edithatogo/anz-legislation` until the
+repository has actually been renamed. Before that point:
+
+- product copy may be `ANZ Legislation`
+- repo links stay on `edithatogo/nz-legislation`
+- docs should explain the naming transition when needed
+
+### Rule 5: Historical Documents Must Be Triaged, Not Normalized Blindly
+
+Older release, publishing, and setup documents may reflect past operational
+states. They should be classified before editing:
+
+- current canonical guidance
+- historical record
+- obsolete material that can be archived or removed
+
+## Safe Early Edit Set
+
+The following edits are approved to happen before package and CLI migration:
+
+### Safe Now
+
+- change high-level product descriptions from NZ-only wording to
+  `ANZ Legislation`
+- add transition notes explaining that package and CLI names remain legacy for
+  compatibility
+- clean up stale support links that point to obviously wrong historical repos
+  where the correct current repo is still `edithatogo/nz-legislation`
+- update Conductor, governance, and roadmap documents to use the approved ANZ
+  transition language
+
+### Not Safe Yet
+
+- renaming `package.json.name`
+- renaming CLI binary entries in `package.json`
+- changing env vars such as `NZ_LEGISLATION_API_KEY`
+- renaming MCP server identifier in code
+- changing `Conf` project name or default config path handling
+- changing GitHub Pages base URLs before the repository rename is coordinated
+
+## Phase 3 Handover Questions
+
+Phase 3 should answer:
+
+1. Should `anz-legislation` be introduced first as a new package, a shim
+   package, or a later replacement?
+2. Should the future CLI aliases ship in the same release as the package
+   migration or earlier?
+3. How should MCP naming and local config-path migration relate to package and
+   binary alias support?

--- a/conductor/tracks/anz-brand-transition/rules.md
+++ b/conductor/tracks/anz-brand-transition/rules.md
@@ -53,10 +53,10 @@ Do not rewrite repository links to `edithatogo/anz-legislation` until the
 repository has actually been renamed. Before that point:
 
 - product copy may be `ANZ Legislation`
-- repo links stay on `edithatogo/nz-legislation`
+- repository links stay on `edithatogo/nz-legislation`
 - docs should explain the naming transition when needed
 
-### Rule 5: Historical Documents Must Be Triaged, Not Normalized Blindly
+### Rule 5: Historical Documents Must Be Reviewed, Not Normalized Blindly
 
 Older release, publishing, and setup documents may reflect past operational
 states. They should be classified before editing:
@@ -75,7 +75,8 @@ The following edits are approved to happen before package and CLI migration:
   `ANZ Legislation`
 - add transition notes explaining that package and CLI names remain legacy for
   compatibility
-- clean up stale support links that point to obviously wrong historical repos
+- clean up stale support links that point to obviously wrong historical
+  repositories
   where the correct current repo is still `edithatogo/nz-legislation`
 - update Conductor, governance, and roadmap documents to use the approved ANZ
   transition language
@@ -84,7 +85,7 @@ The following edits are approved to happen before package and CLI migration:
 
 - renaming `package.json.name`
 - renaming CLI binary entries in `package.json`
-- changing env vars such as `NZ_LEGISLATION_API_KEY`
+- changing environment variables such as `NZ_LEGISLATION_API_KEY`
 - renaming MCP server identifier in code
 - changing `Conf` project name or default config path handling
 - changing GitHub Pages base URLs before the repository rename is coordinated

--- a/conductor/tracks/anz-brand-transition/spec.md
+++ b/conductor/tracks/anz-brand-transition/spec.md
@@ -67,6 +67,34 @@ Legacy names remain valid during the compatibility window:
 - `nzlegislation-mcp`
 - repo references to `edithatogo/nz-legislation`
 
+## Compatibility Window Policy
+
+The compatibility window begins when a replacement public surface is first
+available to users.
+
+- minimum duration: `90 days`
+- minimum release count: `2 minor releases`
+- legacy package and CLI names must remain functional during the full window
+- documentation must label the old names as legacy aliases while replacements
+  are introduced
+- removal of old names requires published migration notes and a passed Phase 5
+  Conductor review gate
+
+## Canonical Surface Policy
+
+During the migration, the canonical state for each public surface is:
+
+- product copy can move first to `ANZ Legislation`
+- repository rename to `anz-legislation` is approved, but deferred until Phase 4
+- npm package remains canonically `nz-legislation-tool` until a dual-publish or
+  migration path exists
+- CLI binaries remain canonically `nzlegislation` and `nzlegislation-mcp` until
+  alias support is implemented
+- MCP metadata remains canonically `nz-legislation` until package, docs, and
+  repo transitions can move together
+- local config and log paths must continue reading the existing
+  `.nz-legislation-tool` state throughout the compatibility window
+
 ## Required Outcomes
 
 1. A canonical rename policy exists before public renaming starts.

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 /**
- * NZ Legislation CLI
- * Command-line interface for searching and retrieving NZ legislation data
+ * ANZ Legislation CLI
+ * Command-line interface for searching and retrieving legislation data
  */
 
 import chalk from 'chalk';
@@ -63,7 +63,7 @@ Examples:
   $ nzlegislation config --show
   $ nzlegislation cache --stats
 
-Documentation: https://github.com/dylanmordaunt/nz-legislation-tool
+Documentation: https://github.com/edithatogo/nz-legislation
 API Documentation: https://api.legislation.govt.nz/docs/`
   );
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -64,7 +64,7 @@ Examples:
   $ nzlegislation cache --stats
 
 Documentation: https://github.com/edithatogo/nz-legislation
-API Documentation: https://api.legislation.govt.nz/docs/`
+NZ API Documentation: https://api.legislation.govt.nz/docs/`
   );
 
 // Add global options


### PR DESCRIPTION
## Summary
- complete the ANZ transition conductor track planning artifacts through implementation-ready status
- update the conductor status to reflect the track's current implementation-ready state
- start the first safe ANZ-first copy slice in top-level docs and CLI help without changing package, binary, env-var, MCP, or config-path compatibility surfaces

## Validation
- pnpm exec prettier --write README.md CONTRIBUTING.md DEVELOPER_GUIDE.md src/cli.ts
- pnpm exec vale README.md CONTRIBUTING.md DEVELOPER_GUIDE.md
- pnpm typecheck
- node scripts/conductor-phase-review.mjs --track anz-brand-transition --phase 1
- node scripts/conductor-phase-review.mjs --track anz-brand-transition --phase 2
- node scripts/conductor-phase-review.mjs --track anz-brand-transition --phase 3
- node scripts/conductor-phase-review.mjs --track anz-brand-transition --phase 4
- node scripts/conductor-phase-review.mjs --track anz-brand-transition --phase 5