### PR TITLE
feat: add ANZ CLI aliases

### DIFF
--- a/.changeset/loud-camels-share.md
+++ b/.changeset/loud-camels-share.md
@@ -1,0 +1,5 @@
+---
+'nz-legislation-tool': patch
+---
+
+Add `anzlegislation` and `anzlegislation-mcp` as supported CLI aliases while keeping the legacy binary names in place, and document the alias availability in the README.

--- a/README.md
+++ b/README.md
@@ -62,8 +62,7 @@ Example MCP command configuration:
 ```
 
 The current package exposes both the legacy binaries and the new ANZ aliases:
-`nzlegislation`, `anzlegislation`, `nzlegislation-mcp`, and
-`anzlegislation-mcp`.
+`nzlegislation`, `anzlegislation`, `nzlegislation-mcp`, and `anzlegislation-mcp`.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -35,6 +35,8 @@ Use the CLI if you want direct terminal access for search, retrieval, export, an
 ```bash
 npm install -g nz-legislation-tool
 nzlegislation search --query "health act"
+# Or use the new ANZ alias after install
+anzlegislation search --query "health act"
 ```
 
 ### MCP Server
@@ -44,6 +46,8 @@ Use the MCP server if you want to connect the tool to an AI assistant or tool-ca
 ```bash
 npm install -g nz-legislation-tool
 nzlegislation-mcp
+# Or use the new ANZ MCP alias after install
+anzlegislation-mcp
 ```
 
 Example MCP command configuration:
@@ -56,6 +60,10 @@ Example MCP command configuration:
   }
 }
 ```
+
+The current package exposes both the legacy binaries and the new ANZ aliases:
+`nzlegislation`, `anzlegislation`, `nzlegislation-mcp`, and
+`anzlegislation-mcp`.
 
 ---
 

--- a/package.json
+++ b/package.json
@@ -6,7 +6,9 @@
   "main": "dist/cli.js",
   "bin": {
     "nzlegislation": "./dist/cli.js",
-    "nzlegislation-mcp": "./dist/mcp-cli.js"
+    "anzlegislation": "./dist/cli.js",
+    "nzlegislation-mcp": "./dist/mcp-cli.js",
+    "anzlegislation-mcp": "./dist/mcp-cli.js"
   },
   "scripts": {
     "dev": "tsx src/cli.ts",

--- a/tests/package-manifest.test.ts
+++ b/tests/package-manifest.test.ts
@@ -9,9 +9,11 @@ describe('package manifest', () => {
       bin: Record<string, string>;
     };
 
-    expect(packageJson.bin.nzlegislation).toBe('./dist/cli.js');
-    expect(packageJson.bin.anzlegislation).toBe('./dist/cli.js');
-    expect(packageJson.bin['nzlegislation-mcp']).toBe('./dist/mcp-cli.js');
-    expect(packageJson.bin['anzlegislation-mcp']).toBe('./dist/mcp-cli.js');
+    expect(packageJson.bin).toEqual({
+      nzlegislation: './dist/cli.js',
+      anzlegislation: './dist/cli.js',
+      'nzlegislation-mcp': './dist/mcp-cli.js',
+      'anzlegislation-mcp': './dist/mcp-cli.js',
+    });
   });
 });

--- a/tests/package-manifest.test.ts
+++ b/tests/package-manifest.test.ts
@@ -1,10 +1,10 @@
 import { describe, expect, it } from 'vitest';
 import { readFileSync } from 'node:fs';
-import { join } from 'node:path';
+import { fileURLToPath } from 'node:url';
 
 describe('package manifest', () => {
   it('exposes both legacy and ANZ CLI binaries', () => {
-    const packageJsonPath = join(process.cwd(), 'package.json');
+    const packageJsonPath = fileURLToPath(new URL('../package.json', import.meta.url));
     const packageJson = JSON.parse(readFileSync(packageJsonPath, 'utf8')) as {
       bin: Record<string, string>;
     };

--- a/tests/package-manifest.test.ts
+++ b/tests/package-manifest.test.ts
@@ -1,0 +1,17 @@
+import { describe, expect, it } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+describe('package manifest', () => {
+  it('exposes both legacy and ANZ CLI binaries', () => {
+    const packageJsonPath = join(process.cwd(), 'package.json');
+    const packageJson = JSON.parse(readFileSync(packageJsonPath, 'utf8')) as {
+      bin: Record<string, string>;
+    };
+
+    expect(packageJson.bin.nzlegislation).toBe('./dist/cli.js');
+    expect(packageJson.bin.anzlegislation).toBe('./dist/cli.js');
+    expect(packageJson.bin['nzlegislation-mcp']).toBe('./dist/mcp-cli.js');
+    expect(packageJson.bin['anzlegislation-mcp']).toBe('./dist/mcp-cli.js');
+  });
+});


### PR DESCRIPTION
## Summary
- add nzlegislation and nzlegislation-mcp binary aliases alongside the legacy binaries
- document the alias availability in the README install examples
- add a package-manifest test to lock the alias contract

## Validation
- pnpm exec vale README.md
- pnpm test:run -- tests/package-manifest.test.ts tests/e2e/cli.test.ts
- pnpm typecheck