### PR TITLE
feat: add canonical legal metadata layer

### DIFF
--- a/.changeset/fifty-towns-care.md
+++ b/.changeset/fifty-towns-care.md
@@ -1,0 +1,5 @@
+---
+'nz-legislation-tool': patch
+---
+
+Add a standards-aligned canonical legal metadata layer with additive export metadata and schema.org publication helpers.

--- a/.github/styles/config/vocabularies/NZLegislation/accept.txt
+++ b/.github/styles/config/vocabularies/NZLegislation/accept.txt
@@ -14,6 +14,8 @@ nzlegislation-mcp
 Alexa
 Algolia
 APIs
+Akoma
+auditable
 backoff
 changeset
 changesets
@@ -23,6 +25,7 @@ Contentful
 CSV
 deduplication
 dev
+discoverability
 Docusaurus
 Enum
 ESLint
@@ -38,6 +41,7 @@ hotspot
 includeMetadata
 JSON
 laggy
+LegalDocML
 lodash
 lookups
 mailto
@@ -45,15 +49,19 @@ Mendeley
 Minecraft
 monospace
 Netlify
+Ntoso
 nzmj
+onboarding
 Profiler
 reo
 Repo
 Resizable
+schema.org
 searchWorks
 Siri
 sudo
 te
+URIs
 Vercel
 workId
 Zod

--- a/conductor/README.md
+++ b/conductor/README.md
@@ -35,6 +35,7 @@ when they materially improve traceability.
 - `documentation-site-completion`
 - `documentation-site-enhancements`
 - `anz-brand-transition`
+- `legal-metadata-standards-alignment`
 
 ## Operating Rule
 

--- a/conductor/status.md
+++ b/conductor/status.md
@@ -16,12 +16,13 @@ See also:
 
 ## Active Track Inventory
 
-| Track                              | Status   | Notes                                     |
-| ---------------------------------- | -------- | ----------------------------------------- |
-| `release-governance-modernization` | COMPLETE | Fully documented and marked complete      |
-| `documentation-site-enhancements`  | PENDING  | Optional post-launch work not yet started |
-| `documentation-site-completion`    | COMPLETE | Parent completion record restored         |
-| `anz-brand-transition`             | ACTIVE   | Planning complete; implementation is next |
+| Track                                | Status   | Notes                                                           |
+| ------------------------------------ | -------- | --------------------------------------------------------------- |
+| `release-governance-modernization`   | COMPLETE | Fully documented and marked complete                            |
+| `documentation-site-enhancements`    | PENDING  | Optional post-launch work not yet started                       |
+| `documentation-site-completion`      | COMPLETE | Parent completion record restored                               |
+| `anz-brand-transition`               | ACTIVE   | Planning complete; implementation is next                       |
+| `legal-metadata-standards-alignment` | COMPLETE | Canonical standards layer documented and implemented additively |
 
 ## Archived Tracks
 
@@ -51,8 +52,15 @@ detail under `research-conductor` instead of this product-side Conductor tree.
   than an implicit future rename.
 - ANZ transition planning is complete across naming policy, inventory, package
   strategy, repo/docs migration, and deprecation criteria.
+- Legal metadata standards alignment is now tracked as an explicit architecture
+  effort rather than an implicit future refactor.
+- Legal metadata standards alignment now has an accepted ADR, canonical
+  schemas, provider mapping, canonical-backed legacy adapters, additive export
+  metadata, and a schema.org publication helper.
 - The product still ships as `nz-legislation-tool`, and package or binary
   renaming has not started yet.
+- The provider model is coherent internally, and a standards-aligned canonical
+  legal metadata layer now exists additively without breaking the CLI surface.
 - The former template track has been moved out of active inventory to
   `conductor/templates`.
 - Former stub tracks have been moved out of active inventory to
@@ -67,3 +75,5 @@ detail under `research-conductor` instead of this product-side Conductor tree.
    active track’s `index.md` and `plan.md`.
 3. Promote backlog entries back into `conductor/tracks` only when they gain a
    real owner, scope, and plan.
+4. Open a follow-on track only when source-derived legal relationship extraction
+   or dataset-level publication metadata becomes a concrete delivery need.

--- a/conductor/tracks/legal-metadata-standards-alignment/index.md
+++ b/conductor/tracks/legal-metadata-standards-alignment/index.md
@@ -1,0 +1,59 @@
+# Track: Legal Metadata Standards Alignment
+
+## Context
+
+- [Specification](./spec.md)
+- [Implementation Plan](./plan.md)
+- [Metadata](./metadata.json)
+- [ADR 0004](../../../docs/adr/0004-standards-aligned-canonical-legal-metadata.md)
+- [Developer Guide: Legal Metadata Standards](../../../docs/developer-guide/legal-metadata-standards.md)
+- [Relationship and Publication Follow-Through](./relationship-publication-follow-through.md)
+
+## Status
+
+🟢 COMPLETE - Phases 1 through 5 are complete. The repository now has
+documented standards alignment, canonical schemas, provider mapping,
+canonical-backed adapters, additive export metadata, and a publication helper
+
+## Summary
+
+The repository already has a usable internal cross-jurisdiction provider model,
+but it does not yet have a standards-aligned canonical legal metadata layer.
+That gap will become more important as more jurisdictions, exports, public
+metadata, and document relationships are added.
+
+This track introduces a staged implementation path that keeps the current
+provider and CLI model stable while adding a canonical metadata layer aligned
+with Akoma Ntoso, FRBR-style work and expression separation, ELI-style
+identifier patterns, and schema.org publication metadata.
+
+Phases 1 through 5 are complete: the accepted standards set, canonical field
+inventory, ADR decision, developer-facing guidance, canonical schemas, schema
+tests, provider-side canonical mapping, canonical-backed legacy adapters,
+additive export metadata, relationship baseline, and publication helper are now
+in source control. Richer source-derived legal relationships and dataset-level
+publication remain appropriate follow-on work rather than hidden scope.
+
+## Intended Outcome
+
+- provider data can be normalized into a standards-aligned canonical layer
+- the current CLI-facing model remains stable during migration
+- legal identifiers, lifecycle dates, and document relationships become
+  explicit and portable
+- future datasets, site metadata, and new jurisdictions can share a single
+  canonical legal metadata frame
+
+## Review Automation
+
+Use the phase-end review command at the end of each plan phase:
+
+`node scripts/conductor-phase-review.mjs --track legal-metadata-standards-alignment --phase <n>`
+
+For informational checks before a phase is complete:
+
+`node scripts/conductor-phase-review.mjs --track legal-metadata-standards-alignment --phase <n> --allow-open-tasks`
+
+---
+
+**Track ID:** `legal-metadata-standards-alignment`  
+**Last Updated:** 2026-03-14

--- a/conductor/tracks/legal-metadata-standards-alignment/metadata.json
+++ b/conductor/tracks/legal-metadata-standards-alignment/metadata.json
@@ -1,0 +1,10 @@
+{
+  "track_id": "legal-metadata-standards-alignment",
+  "type": "feature",
+  "status": "complete",
+  "created_at": "2026-03-14T15:05:00+11:00",
+  "updated_at": "2026-03-14T15:05:00+11:00",
+  "current_phase": "complete",
+  "planning_complete": true,
+  "description": "Introduce a standards-aligned canonical legal metadata layer across jurisdictions without breaking the current CLI-facing provider model"
+}

--- a/conductor/tracks/legal-metadata-standards-alignment/plan.md
+++ b/conductor/tracks/legal-metadata-standards-alignment/plan.md
@@ -1,0 +1,150 @@
+# Plan: Legal Metadata Standards Alignment
+
+**Track ID:** legal-metadata-standards-alignment  
+**Status:** 🟡 IN PROGRESS  
+**Priority:** 🔴 HIGH  
+**Last Updated:** 2026-03-14
+
+## Summary
+
+This plan adds a canonical legal metadata layer aligned with recognized legal
+information standards while preserving the current provider and CLI behavior.
+
+## Phase 1: Standards Decision and Canonical Field Inventory
+
+### Goals
+
+- confirm the standards set the project will align to
+- define the minimum canonical entities and fields
+- document non-goals and migration constraints
+
+### Outputs
+
+- accepted ADR
+- developer-guide standards document
+- canonical field inventory linked to current provider concepts
+
+### Phase 1 Outcome
+
+- `ADR 0004` accepts the standards-aligned canonical metadata direction
+- the developer guide now documents the selected standards and canonical entity
+  frame
+- no exceptions were recorded before schema work starts
+
+### Automated Review Gate
+
+- [x] Run `node scripts/conductor-phase-review.mjs --track legal-metadata-standards-alignment --phase 1`
+- [x] Confirm the standards set and canonical fields are documented
+- [x] Record any exceptions before schema work starts
+
+## Phase 2: Canonical Schema Introduction
+
+### Goals
+
+- add canonical TypeScript and Zod schemas
+- define work, expression, manifestation, and relationship entities
+- separate canonical and CLI-facing model responsibilities
+
+### Outputs
+
+- canonical schemas in source control
+- unit tests for the canonical schemas
+- architecture documentation updated for the two-layer model
+
+### Phase 2 Outcome
+
+- canonical work, expression, manifestation, relationship, and record schemas
+  now exist in `src/models/canonical.ts`
+- focused unit coverage exists for canonical schema validation
+- the architecture guide now links the application-facing provider model to the
+  standards-aligned canonical layer
+
+### Automated Review Gate
+
+- [x] Run `node scripts/conductor-phase-review.mjs --track legal-metadata-standards-alignment --phase 2`
+- [x] Verify canonical schemas cover current jurisdiction needs
+- [x] Confirm no CLI contract regressions have been introduced
+
+## Phase 3: Provider Mapping
+
+### Goals
+
+- map NZ, Commonwealth, and Queensland providers into canonical entities
+- isolate source-specific parsing inside provider mappers
+- keep adapters deterministic and testable
+
+### Outputs
+
+- per-provider canonical mapping implementation
+- fixture-backed tests for mapping behavior
+- canonical identifier and lifecycle derivation rules
+
+### Phase 3 Outcome
+
+- provider-side canonical mapping now exists in `src/providers/canonical-metadata.ts`
+- current jurisdiction fixtures are covered by focused canonical mapping tests
+- canonical work, expression, manifestation, and relationship identifiers are
+  now derived consistently from provider data
+
+### Automated Review Gate
+
+- [x] Run `node scripts/conductor-phase-review.mjs --track legal-metadata-standards-alignment --phase 3`
+- [x] Verify each provider maps into canonical entities
+- [x] Confirm adapters remain reversible and auditable
+
+## Phase 4: CLI and Export Integration
+
+### Goals
+
+- adapt the current CLI-facing model from canonical metadata
+- expose canonical metadata selectively in exports
+- prepare future web or API metadata publication paths
+
+### Outputs
+
+- canonical-to-CLI adapters
+- export metadata improvements
+- documentation for migration-safe public exposure
+
+### Phase 4 Outcome
+
+- the legacy CLI-facing provider adapters now derive from canonical records
+  internally
+- export metadata can now include additive canonical records without changing
+  the default export shape
+- focused tests cover canonical-backed adapter behavior and canonical export
+  metadata generation
+
+### Automated Review Gate
+
+- [x] Run `node scripts/conductor-phase-review.mjs --track legal-metadata-standards-alignment --phase 4`
+- [x] Verify the CLI output remains stable unless explicitly expanded
+- [x] Confirm export changes are documented and tested
+
+## Phase 5: Relationship and Publication Follow-Through
+
+### Goals
+
+- add structured legal relationships where the source quality allows
+- define publication patterns for schema.org and dataset metadata
+- establish the closure standard for the standards-alignment track
+
+### Outputs
+
+- relationship model coverage plan
+- publication metadata guidance
+- closure criteria or follow-on backlog entries
+
+### Phase 5 Outcome
+
+- baseline canonical relationships are explicitly limited to safe structural
+  links
+- schema.org publication guidance is implemented and documented
+- deferred relationship extraction and dataset publication work is recorded as
+  follow-on scope rather than left ambiguous
+
+### Automated Review Gate
+
+- [x] Run `node scripts/conductor-phase-review.mjs --track legal-metadata-standards-alignment --phase 5`
+- [x] Confirm publication and relationship follow-through is documented
+- [x] Decide whether the track can close or should split into follow-on work

--- a/conductor/tracks/legal-metadata-standards-alignment/relationship-publication-follow-through.md
+++ b/conductor/tracks/legal-metadata-standards-alignment/relationship-publication-follow-through.md
@@ -1,0 +1,86 @@
+# Relationship and Publication Follow-Through
+
+## Purpose
+
+This document closes Phase 5 of the legal metadata standards alignment track.
+It records what relationship and publication work is already implemented, what
+is deferred, and why the current track can close without pretending that all
+possible legal relationship extraction has been solved.
+
+## Implemented Now
+
+### Relationship Baseline
+
+The canonical layer now emits structural relationships that are always safe and
+derivable from current provider data:
+
+- `has_expression`
+- `has_manifestation`
+
+These are emitted in provider-side canonical mapping and give every canonical
+record an explicit work-expression-manifestation chain.
+
+### Publication Baseline
+
+The repository now has a direct publication helper for
+`schema.org/Legislation`:
+
+- `src/output/legal-metadata-publication.ts`
+
+This provides a stable projection from canonical records into web-facing
+metadata suitable for future documentation pages, HTTP surfaces, or generated
+site markup.
+
+### Export Baseline
+
+JSON exports with `--include-metadata` now include additive `canonicalRecords`
+output. CSV exports keep row compatibility and only add metadata comments.
+
+## Deferred Relationship Coverage
+
+The following relationship families are still relevant, but remain source-data
+dependent and should not be faked:
+
+- `amends`
+- `amended_by`
+- `repeals`
+- `repealed_by`
+- `commences`
+- `commenced_by`
+- `derived_from`
+- `supersedes`
+
+These should move into a follow-on implementation only when the underlying
+provider data is reliable enough to populate them deterministically.
+
+## Deferred Publication Follow-Through
+
+The following publication tasks are intentionally deferred:
+
+- dataset-level `DCAT` publication for bulk exports
+- automatic JSON-LD embedding in generated documentation pages
+- public HTTP metadata surfaces governed under the HTTP/OpenAPI ADR
+- richer citation and jurisdiction publication metadata beyond the current
+  canonical baseline
+
+## Closure Standard
+
+This standards-alignment track can be marked complete because it now has:
+
+- a documented standards decision
+- canonical schemas
+- provider-side canonical mapping
+- canonical-backed legacy adapters
+- additive canonical export metadata
+- a publication helper for `schema.org/Legislation`
+- an explicit record of deferred relationship and publication work
+
+## Recommended Follow-On Work
+
+If future jurisdictions or source APIs expose structured legislative
+relationships, open a follow-on track for:
+
+1. relationship extraction by provider
+2. relationship test fixtures
+3. dataset-level `DCAT` publication
+4. JSON-LD embedding on public documentation or future HTTP surfaces

--- a/conductor/tracks/legal-metadata-standards-alignment/spec.md
+++ b/conductor/tracks/legal-metadata-standards-alignment/spec.md
@@ -1,0 +1,62 @@
+# Specification: Legal Metadata Standards Alignment
+
+**Track ID:** legal-metadata-standards-alignment  
+**Type:** feature  
+**Status:** 🟡 IN PROGRESS  
+**Last Updated:** 2026-03-14
+
+## Problem
+
+The current provider abstraction is coherent inside the product, but it is not
+formally aligned to a legal metadata standard. As a result:
+
+- identifiers are source-specific and only loosely normalized
+- work and version semantics are implicit rather than canonical
+- jurisdiction expansion risks accumulating product-local metadata drift
+- future exports and site metadata will be harder to standardize
+
+## Goal
+
+Add a standards-aligned canonical legal metadata layer without breaking the
+existing CLI-facing provider contract.
+
+## Scope
+
+In scope:
+
+- standards selection and documentation
+- canonical TypeScript and Zod schemas
+- provider-to-canonical mapping rules
+- canonical-to-CLI adapter boundaries
+- lifecycle and relationship field definitions
+- tests that lock the canonical mapping shape
+
+Out of scope:
+
+- immediate full Akoma Ntoso XML generation
+- a new public HTTP API
+- full relationship extraction from every source in the first pass
+- LegalRuleML implementation
+
+## Standards Position
+
+Primary standards:
+
+- `Akoma Ntoso`
+- `FRBR` concepts
+- `ELI`-style identifiers
+- `schema.org/Legislation`
+
+Secondary standards:
+
+- `DCAT` for dataset publication
+- `LegalRuleML` for future rules modeling only
+
+## Success Criteria
+
+- canonical schemas exist and are documented
+- at least the existing NZ, Commonwealth, and Queensland providers map into the
+  canonical model
+- the current CLI surface continues to work through adapters
+- architecture docs explain the two-layer model clearly
+- future jurisdictions have a clear canonical onboarding pattern

--- a/docs/adr/0004-standards-aligned-canonical-legal-metadata.md
+++ b/docs/adr/0004-standards-aligned-canonical-legal-metadata.md
@@ -1,0 +1,83 @@
+# ADR 0004: Add a Standards-Aligned Canonical Legal Metadata Layer
+
+## Status
+
+Accepted
+
+## Context
+
+The current codebase has a clear internal cross-jurisdiction provider model for
+search, work retrieval, versions, citations, caching, and health monitoring.
+That model is intentionally product-oriented and normalizes New Zealand,
+Commonwealth, and Queensland sources into a common TypeScript interface.
+
+What it does not currently provide is a standards-aligned canonical metadata
+layer for legislation that can be reused across jurisdictions, published
+externally, or mapped cleanly to future legal XML and metadata ecosystems.
+
+As more jurisdictions are added, the absence of a canonical standards layer
+creates three problems:
+
+- identifiers and version semantics remain product-local rather than portable
+- relationships such as amendment, repeal, commencement, and consolidation stay
+  ad hoc
+- future interoperability with bulk datasets, site metadata, and legal document
+  exchange formats becomes harder
+
+## Decision
+
+The project will keep the existing provider interface as its application-facing
+domain model, but add a standards-aligned canonical metadata layer beneath it.
+
+The canonical layer should align to the following standards in order of
+importance:
+
+- `Akoma Ntoso` for legislative document structure and lifecycle semantics
+- `FRBR` concepts for work, expression, and manifestation separation
+- `ELI`-style identifiers and metadata publication patterns for stable legal
+  resource identity
+- `schema.org/Legislation` for web-facing discoverability
+
+The following standards are relevant but secondary:
+
+- `DCAT` for dataset publication and catalog metadata, not core document
+  modeling
+- `LegalRuleML` for machine-readable norms and reasoning, only if the project
+  later models executable legal rules
+
+The canonical layer should introduce explicit fields for:
+
+- source identity: `source_system`, `source_id`, `source_url`
+- canonical identity: `canonical_id`, `work_uri`, `expression_uri`,
+  `manifestation_uri`
+- legal classification: `jurisdiction_code`, `document_type`,
+  `lifecycle_state`, `language`
+- temporal metadata: `publication_date`, `commencement_date`,
+  `in_force_date`, `repeal_date`
+- versioning metadata: `version_date`, `is_current`, `expression_date`
+- citation metadata: `preferred_citation`, `neutral_citation`
+- relationship metadata: amendment, repeal, commencement, and derivation links
+
+## Consequences
+
+### Positive
+
+- future jurisdictions can map into a durable legal metadata frame
+- the product can support richer legal relationships without bloating the
+  CLI-facing model
+- XML, web metadata, and export work can align to recognized legal information
+  standards
+- site and API metadata can become more interoperable without rewriting the
+  application surface
+
+### Negative
+
+- provider implementations will need an extra normalization layer
+- some source systems will not map perfectly to Akoma Ntoso or ELI patterns
+- the project will need explicit governance to prevent standards drift
+
+### Non-Goals
+
+- immediate conversion of all source content to full Akoma Ntoso XML
+- immediate exposure of a public standards-based HTTP API
+- implementation of LegalRuleML in the current release cycle

--- a/docs/developer-guide/architecture.md
+++ b/docs/developer-guide/architecture.md
@@ -16,6 +16,23 @@ The NZ Legislation Tool is a TypeScript-based command-line interface (CLI) that 
 - **Testability** - Designed for unit, integration, and E2E testing
 - **Maintainability** - Clear code organization and documentation
 
+## Standards Direction
+
+The current provider interface is the application-facing cross-jurisdiction
+model. It should remain stable for CLI and runtime behavior.
+
+The repository also now has an accepted standards direction for a canonical
+legal metadata layer beneath that interface. That canonical layer should align
+to:
+
+- `Akoma Ntoso` for legal document structure and lifecycle concepts
+- `FRBR` concepts for work, expression, and manifestation separation
+- `ELI`-style identifiers for stable legal resource identity
+- `schema.org/Legislation` for web publication metadata
+
+See [Legal Metadata Standards](./legal-metadata-standards.md) and
+[ADR 0004](../adr/0004-standards-aligned-canonical-legal-metadata.md).
+
 ---
 
 ## High-Level Architecture

--- a/docs/developer-guide/index.md
+++ b/docs/developer-guide/index.md
@@ -43,6 +43,7 @@ This guide is for developers who want to:
 - [Module Documentation](./modules/) - Detailed module docs
 - [MCP Server](./mcp-server.md) - Model Context Protocol integration
 - [Performance](./performance.md) - Optimization tips
+- [Legal Metadata Standards](./legal-metadata-standards.md) - Canonical legal metadata model and standards alignment
 
 ---
 

--- a/docs/developer-guide/legal-metadata-standards.md
+++ b/docs/developer-guide/legal-metadata-standards.md
@@ -1,0 +1,252 @@
+# Legal Metadata Standards
+
+This document defines the recommended standards frame for legislation metadata
+across all supported jurisdictions in this repository.
+
+## Current State
+
+The codebase already has a clear internal cross-jurisdiction framework:
+
+- providers normalize source systems into shared `search`, `work`, and
+  `version` objects
+- the CLI reads a single jurisdiction-agnostic provider interface
+- output adapters translate provider results into the existing CLI-facing models
+
+That is good application architecture, but it is not yet a standards-aligned
+legal metadata model. The current shared model is product-local and optimized
+for CLI behavior rather than long-term legal information interoperability.
+
+## Recommended Model Strategy
+
+Use two layers:
+
+1. Keep the current provider and CLI model as the application layer.
+2. Add a canonical metadata layer aligned to legal-information standards.
+
+This avoids breaking the current user-facing interfaces while making future
+jurisdictions, exports, and documentation metadata more coherent.
+
+## Standards to Use
+
+### Primary Standards
+
+#### Akoma Ntoso
+
+Use `Akoma Ntoso` as the structural reference for legislative documents and
+their lifecycle semantics.
+
+Use it for:
+
+- document structure
+- component naming
+- lifecycle and event semantics
+- relationship modeling between principal works and later expressions
+
+Do not require immediate full XML conversion. Treat it as the canonical
+reference model for concepts and naming.
+
+#### FRBR Concepts
+
+Use `FRBR` concepts to separate:
+
+- `Work`
+- `Expression`
+- `Manifestation`
+
+The current code already distinguishes a legislation work from its versions,
+but it does so informally. Make that distinction explicit in canonical
+metadata.
+
+#### ELI-Style Identifiers
+
+Use `ELI` patterns for stable identifiers and public metadata publication.
+
+Use them for:
+
+- canonical URIs
+- legal resource identity across systems
+- web-facing metadata records
+
+This does not require formal participation in the European ELI program. The
+value is the identifier and metadata pattern.
+
+#### schema.org/Legislation
+
+Use `schema.org/Legislation` for site and web metadata publication.
+
+Use it for:
+
+- public documentation pages
+- search-engine discoverability
+- structured metadata on legislation detail pages or future HTTP surfaces
+
+### Secondary Standards
+
+#### DCAT
+
+Use `DCAT` for dataset-level publication only.
+
+Good fit:
+
+- bulk exports
+- data catalogs
+- dataset download metadata
+
+Poor fit:
+
+- modeling the core legal work/version abstraction
+
+#### LegalRuleML
+
+Treat `LegalRuleML` as a future-only standard unless the product starts
+representing executable norms, obligations, logic, or compliance reasoning.
+
+It is relevant, but not the first standard this tool should implement.
+
+## Canonical Entity Frame
+
+The project should introduce a canonical metadata model with three core layers.
+
+### Canonical Work
+
+Represents the enduring legal instrument.
+
+Recommended fields:
+
+- `canonical_id`
+- `source_system`
+- `source_id`
+- `jurisdiction_code`
+- `document_type`
+- `title`
+- `short_title`
+- `language`
+- `work_uri`
+- `preferred_citation`
+- `neutral_citation`
+
+### Canonical Expression
+
+Represents a dated legal expression or consolidated version of the work.
+
+Recommended fields:
+
+- `expression_uri`
+- `work_uri`
+- `expression_date`
+- `publication_date`
+- `commencement_date`
+- `in_force_date`
+- `repeal_date`
+- `lifecycle_state`
+- `is_current`
+- `version_label`
+
+### Canonical Manifestation
+
+Represents a concrete published representation of an expression.
+
+Recommended fields:
+
+- `manifestation_uri`
+- `expression_uri`
+- `format`
+- `media_type`
+- `source_url`
+- `hash`
+- `retrieved_at`
+
+## Relationship Model
+
+The canonical layer should support structured relationships rather than leaving
+them as free text.
+
+Minimum relationship types:
+
+- `amends`
+- `amended_by`
+- `repeals`
+- `repealed_by`
+- `commences`
+- `commenced_by`
+- `derived_from`
+- `supersedes`
+- `has_expression`
+- `has_manifestation`
+
+The currently implemented baseline relationships are `has_expression` and
+`has_manifestation`. Richer legislative relationships remain intentionally
+deferred until provider data quality is sufficient to populate them
+deterministically.
+
+## Mapping to Current Code
+
+### Existing Internal Model
+
+The current provider model already contains:
+
+- `work_id`
+- `title`
+- `type`
+- `year`
+- `number`
+- `jurisdiction`
+- `status`
+- `versions`
+- `citations`
+
+This should remain the CLI-facing shape for now.
+
+### Needed Canonical Additions
+
+The missing canonical concepts are:
+
+- explicit work/expression/manifestation separation
+- canonical URIs independent of source-specific IDs
+- richer lifecycle dates
+- relationship metadata
+- language and expression metadata
+- consistent status semantics across jurisdictions
+
+The initial provider-side canonical mapper now lives in
+`src/providers/canonical-metadata.ts`. It is intentionally additive: providers
+can emit canonical records without changing the current CLI-facing adapter path.
+
+## Recommended Implementation Order
+
+1. Define canonical TypeScript and Zod schemas beside the existing provider
+   types.
+2. Add per-provider mapping into canonical work, expression, and manifestation
+   entities.
+3. Adapt existing provider outputs from canonical metadata into the current CLI
+   model.
+4. Add canonical metadata to exports and future HTTP or site metadata surfaces.
+5. Add structured relationship support as source quality improves.
+
+The first part of Step 3 is now implemented. The existing provider
+`output-adapters` derive legacy CLI-facing work objects from canonical records
+internally, while preserving the current CLI output shape.
+
+The first part of Step 4 is also now implemented. JSON exports with
+`--include-metadata` include additive `canonicalRecords` output plus a canonical
+standards note in export metadata. CSV exports remain row-compatible and add
+only metadata comments.
+
+The first publication helper is now implemented in
+`src/output/legal-metadata-publication.ts`, which projects canonical records
+into `schema.org/Legislation` JSON-LD.
+
+## Design Rules
+
+- Do not replace the CLI-facing model in one step.
+- Do not force every provider to emit full Akoma Ntoso XML.
+- Do not treat source IDs as canonical IDs.
+- Keep source-specific parsing isolated inside provider mappers.
+- Make standards alignment explicit in tests and architecture docs.
+
+## Relevant References
+
+- Akoma Ntoso: <https://www.oasis-open.org/committees/legaldocml/>
+- Akoma Ntoso core specification: <https://docs.oasis-open.org/legaldocml/akn-core/v1.0/>
+- ELI overview: <https://eur-lex.europa.eu/eli-register/about.html>
+- schema.org Legislation: <https://schema.org/Legislation>

--- a/src/commands/export.ts
+++ b/src/commands/export.ts
@@ -8,6 +8,7 @@ import { Command } from 'commander';
 import ora from 'ora';
 
 import { searchWorks } from '@client';
+import type { CanonicalLegislationRecord } from '@models';
 import { worksToCsv } from '@output';
 
 interface ExportOptions {
@@ -20,6 +21,78 @@ interface ExportOptions {
   limit: string;
   format: string;
   includeMetadata: boolean;
+}
+
+export function toCanonicalExportRecords(
+  results: Awaited<ReturnType<typeof searchWorks>>
+): Array<
+  Pick<CanonicalLegislationRecord, 'work' | 'expressions' | 'manifestations' | 'relationships'>
+> {
+  return results.results.map(work => {
+    const canonicalId = `legacy:${work.id}`;
+    const workUri = `urn:nz-legislation:work:${work.id.replace(/[^a-zA-Z0-9-]+/g, '-')}`;
+    const expressionUri = `${workUri}:expression:current`;
+    const manifestationUri = `${expressionUri}:manifestation:html`;
+
+    return {
+      work: {
+        canonicalId,
+        workUri,
+        source: {
+          sourceSystem: 'legacy-cli-export',
+          sourceId: work.id,
+          sourceUrl: work.url,
+        },
+        jurisdictionCode: 'unknown',
+        documentType: work.type,
+        title: work.title,
+        shortTitle: work.shortTitle,
+        language: 'en',
+      },
+      expressions: [
+        {
+          expressionUri,
+          workUri,
+          expressionDate: work.date,
+          publicationDate: work.date,
+          lifecycleState:
+            work.status === 'in-force'
+              ? 'in-force'
+              : work.status === 'repealed'
+                ? 'repealed'
+                : work.status === 'withdrawn'
+                  ? 'withdrawn'
+                  : work.status === 'not-yet-in-force'
+                    ? 'not-yet-in-force'
+                    : 'unknown',
+          isCurrent: true,
+          versionLabel: 'current',
+          language: 'en',
+        },
+      ],
+      manifestations: [
+        {
+          manifestationUri,
+          expressionUri,
+          format: 'html',
+          mediaType: 'text/html',
+          sourceUrl: work.url,
+        },
+      ],
+      relationships: [
+        {
+          subjectUri: workUri,
+          relationshipType: 'has_expression',
+          objectUri: expressionUri,
+        },
+        {
+          subjectUri: expressionUri,
+          relationshipType: 'has_manifestation',
+          objectUri: manifestationUri,
+        },
+      ],
+    };
+  });
 }
 
 export const exportCommand = new Command()
@@ -69,8 +142,18 @@ export const exportCommand = new Command()
                 timestamp,
                 totalResults: results.total,
                 exportedCount: results.results.length,
+                canonical: {
+                  standardProfile: [
+                    'Akoma Ntoso concepts',
+                    'FRBR work-expression-manifestation',
+                    'ELI-style identifiers',
+                    'schema.org/Legislation',
+                  ],
+                  included: true,
+                },
               },
               results: results.results,
+              canonicalRecords: toCanonicalExportRecords(results),
             }
           : results;
         output = JSON.stringify(exportData, null, 2);
@@ -85,6 +168,8 @@ export const exportCommand = new Command()
           csvContent += `\n# Timestamp: ${timestamp}`;
           csvContent += `\n# Total Results: ${results.total}`;
           csvContent += `\n# Exported: ${results.results.length}`;
+          csvContent += `\n# Canonical Metadata: included`;
+          csvContent += `\n# Canonical Standards: Akoma Ntoso concepts; FRBR work-expression-manifestation; ELI-style identifiers; schema.org/Legislation`;
           if (options.type) {
             csvContent += `\n# Type: ${options.type}`;
           }

--- a/src/models/canonical.ts
+++ b/src/models/canonical.ts
@@ -1,0 +1,116 @@
+import { z } from 'zod';
+
+export const CanonicalUriSchema = z.string().min(1);
+export type CanonicalUri = z.infer<typeof CanonicalUriSchema>;
+
+export const CanonicalDocumentTypeSchema = z.enum(['act', 'bill', 'regulation', 'instrument']);
+export type CanonicalDocumentType = z.infer<typeof CanonicalDocumentTypeSchema>;
+
+export const CanonicalLifecycleStateSchema = z.enum([
+  'draft',
+  'not-yet-in-force',
+  'in-force',
+  'partially-in-force',
+  'amended',
+  'repealed',
+  'withdrawn',
+  'superseded',
+  'unknown',
+]);
+export type CanonicalLifecycleState = z.infer<typeof CanonicalLifecycleStateSchema>;
+
+export const CanonicalManifestationFormatSchema = z.enum([
+  'html',
+  'pdf',
+  'xml',
+  'json',
+  'docx',
+  'text',
+  'other',
+]);
+export type CanonicalManifestationFormat = z.infer<typeof CanonicalManifestationFormatSchema>;
+
+export const CanonicalRelationshipTypeSchema = z.enum([
+  'amends',
+  'amended_by',
+  'repeals',
+  'repealed_by',
+  'commences',
+  'commenced_by',
+  'derived_from',
+  'supersedes',
+  'has_expression',
+  'has_manifestation',
+]);
+export type CanonicalRelationshipType = z.infer<typeof CanonicalRelationshipTypeSchema>;
+
+export const CanonicalCitationSchema = z.object({
+  preferred: z.string().min(1),
+  neutral: z.string().min(1).optional(),
+  short: z.string().min(1).optional(),
+});
+export type CanonicalCitation = z.infer<typeof CanonicalCitationSchema>;
+
+export const CanonicalSourceReferenceSchema = z.object({
+  sourceSystem: z.string().min(1),
+  sourceId: z.string().min(1),
+  sourceUrl: z.string().url().optional(),
+});
+export type CanonicalSourceReference = z.infer<typeof CanonicalSourceReferenceSchema>;
+
+export const CanonicalWorkSchema = z.object({
+  canonicalId: z.string().min(1),
+  workUri: CanonicalUriSchema,
+  source: CanonicalSourceReferenceSchema,
+  jurisdictionCode: z.string().min(1),
+  documentType: CanonicalDocumentTypeSchema,
+  title: z.string().min(1),
+  shortTitle: z.string().optional(),
+  language: z.string().min(2).default('en'),
+  preferredCitation: z.string().min(1).optional(),
+  neutralCitation: z.string().min(1).optional(),
+});
+export type CanonicalWork = z.infer<typeof CanonicalWorkSchema>;
+
+export const CanonicalExpressionSchema = z.object({
+  expressionUri: CanonicalUriSchema,
+  workUri: CanonicalUriSchema,
+  expressionDate: z.string().date().optional(),
+  publicationDate: z.string().date().optional(),
+  commencementDate: z.string().date().optional(),
+  inForceDate: z.string().date().optional(),
+  repealDate: z.string().date().optional(),
+  lifecycleState: CanonicalLifecycleStateSchema,
+  isCurrent: z.boolean(),
+  versionLabel: z.string().optional(),
+  language: z.string().min(2).default('en'),
+});
+export type CanonicalExpression = z.infer<typeof CanonicalExpressionSchema>;
+
+export const CanonicalManifestationSchema = z.object({
+  manifestationUri: CanonicalUriSchema,
+  expressionUri: CanonicalUriSchema,
+  format: CanonicalManifestationFormatSchema,
+  mediaType: z.string().min(1),
+  sourceUrl: z.string().url().optional(),
+  hash: z.string().optional(),
+  retrievedAt: z.string().datetime().optional(),
+});
+export type CanonicalManifestation = z.infer<typeof CanonicalManifestationSchema>;
+
+export const CanonicalRelationshipSchema = z.object({
+  subjectUri: CanonicalUriSchema,
+  relationshipType: CanonicalRelationshipTypeSchema,
+  objectUri: CanonicalUriSchema,
+  note: z.string().optional(),
+});
+export type CanonicalRelationship = z.infer<typeof CanonicalRelationshipSchema>;
+
+export const CanonicalLegislationRecordSchema = z.object({
+  work: CanonicalWorkSchema,
+  expressions: z.array(CanonicalExpressionSchema),
+  manifestations: z.array(CanonicalManifestationSchema),
+  relationships: z.array(CanonicalRelationshipSchema).default([]),
+  citations: CanonicalCitationSchema.optional(),
+});
+export type CanonicalLegislationRecord = z.infer<typeof CanonicalLegislationRecordSchema>;

--- a/src/models/index.ts
+++ b/src/models/index.ts
@@ -8,6 +8,8 @@
 
 import { z } from 'zod';
 
+export * from './canonical.js';
+
 // Work type enumeration — maps API values to CLI display values
 export const WorkTypeSchema = z.enum(['act', 'bill', 'regulation', 'instrument']);
 export type WorkType = z.infer<typeof WorkTypeSchema>;

--- a/src/output/index.ts
+++ b/src/output/index.ts
@@ -8,6 +8,8 @@ import Table from 'cli-table3';
 
 import type { SearchResults, Version, Work } from '@models';
 
+export * from './legal-metadata-publication.js';
+
 /**
  * Format work type for display
  */

--- a/src/output/legal-metadata-publication.ts
+++ b/src/output/legal-metadata-publication.ts
@@ -1,0 +1,46 @@
+import type { CanonicalLegislationRecord } from '../models/canonical.js';
+
+type SchemaOrgLegislation = {
+  '@context': 'https://schema.org';
+  '@type': 'Legislation';
+  name: string;
+  legislationType: string;
+  legislationIdentifier: string;
+  jurisdiction?: string;
+  inLanguage?: string;
+  url?: string;
+  datePublished?: string;
+  legislationDate?: string;
+  isBasedOn?: string;
+  sameAs?: string[];
+  creativeWorkStatus?: string;
+};
+
+export function toSchemaOrgLegislation(record: CanonicalLegislationRecord): SchemaOrgLegislation {
+  const currentExpression =
+    record.expressions.find(expression => expression.isCurrent) ?? record.expressions[0];
+  const primaryManifestation =
+    record.manifestations.find(
+      manifestation => manifestation.expressionUri === currentExpression?.expressionUri
+    ) ?? record.manifestations[0];
+
+  return {
+    '@context': 'https://schema.org',
+    '@type': 'Legislation',
+    name: record.work.title,
+    legislationType: record.work.documentType,
+    legislationIdentifier: record.work.canonicalId,
+    jurisdiction: record.work.jurisdictionCode,
+    inLanguage: currentExpression?.language ?? record.work.language,
+    url: primaryManifestation?.sourceUrl ?? record.work.source.sourceUrl,
+    datePublished: currentExpression?.publicationDate,
+    legislationDate: currentExpression?.expressionDate,
+    isBasedOn: record.work.source.sourceUrl,
+    sameAs: [
+      record.work.workUri,
+      ...(currentExpression ? [currentExpression.expressionUri] : []),
+      ...record.manifestations.map(manifestation => manifestation.manifestationUri),
+    ],
+    creativeWorkStatus: currentExpression?.lifecycleState,
+  };
+}

--- a/src/providers/canonical-metadata.ts
+++ b/src/providers/canonical-metadata.ts
@@ -1,0 +1,252 @@
+import type {
+  CanonicalLegislationRecord,
+  CanonicalLifecycleState,
+  CanonicalManifestation,
+  CanonicalRelationship,
+  CanonicalWork,
+  CanonicalExpression,
+} from '../models/canonical.js';
+
+import type { VersionSummary, Work } from './legislation-provider.js';
+
+function encodeIdPart(value: string): string {
+  return value
+    .replace(/[^a-zA-Z0-9-]+/g, '-')
+    .replace(/-+/g, '-')
+    .replace(/^-|-$/g, '');
+}
+
+function buildWorkUri(jurisdiction: string, workId: string): string {
+  return `urn:nz-legislation:work:${encodeIdPart(jurisdiction)}:${encodeIdPart(workId)}`;
+}
+
+function buildExpressionUri(workUri: string, versionId: string): string {
+  return `${workUri}:expression:${encodeIdPart(versionId)}`;
+}
+
+function buildManifestationUri(expressionUri: string, format: string): string {
+  return `${expressionUri}:manifestation:${encodeIdPart(format)}`;
+}
+
+function deriveSourceSystem(jurisdiction: string): string {
+  switch (jurisdiction) {
+    case 'nz':
+      return 'nz-legislation-api';
+    case 'au-comm':
+      return 'federal-register-of-legislation';
+    case 'au-qld':
+      return 'queensland-legislation-api';
+    default:
+      return 'unknown-legislation-source';
+  }
+}
+
+function deriveDocumentType(type: string): CanonicalWork['documentType'] {
+  switch (type) {
+    case 'act':
+    case 'bill':
+    case 'regulation':
+    case 'instrument':
+      return type;
+    default:
+      return 'instrument';
+  }
+}
+
+function deriveLifecycleState(status?: string): CanonicalLifecycleState {
+  switch (status) {
+    case 'in-force':
+      return 'in-force';
+    case 'not-yet-in-force':
+      return 'not-yet-in-force';
+    case 'partially-repealed':
+      return 'amended';
+    case 'repealed':
+    case 'not-in-force':
+      return 'repealed';
+    case 'withdrawn':
+      return 'withdrawn';
+    default:
+      return 'unknown';
+  }
+}
+
+function deriveManifestationFormat(format: string): CanonicalManifestation['format'] {
+  switch (format.toLowerCase()) {
+    case 'html':
+      return 'html';
+    case 'pdf':
+      return 'pdf';
+    case 'xml':
+      return 'xml';
+    case 'json':
+      return 'json';
+    case 'docx':
+      return 'docx';
+    case 'txt':
+    case 'text':
+      return 'text';
+    default:
+      return 'other';
+  }
+}
+
+function deriveMediaType(format: CanonicalManifestation['format']): string {
+  switch (format) {
+    case 'html':
+      return 'text/html';
+    case 'pdf':
+      return 'application/pdf';
+    case 'xml':
+      return 'application/xml';
+    case 'json':
+      return 'application/json';
+    case 'docx':
+      return 'application/vnd.openxmlformats-officedocument.wordprocessingml.document';
+    case 'text':
+      return 'text/plain';
+    default:
+      return 'application/octet-stream';
+  }
+}
+
+function buildCanonicalWork(work: Work, workUri: string): CanonicalWork {
+  return {
+    canonicalId: `${work.jurisdiction}:${work.work_id}`,
+    workUri,
+    source: {
+      sourceSystem: deriveSourceSystem(work.jurisdiction),
+      sourceId: work.work_id,
+      sourceUrl: work.url,
+    },
+    jurisdictionCode: work.jurisdiction,
+    documentType: deriveDocumentType(work.type),
+    title: work.title,
+    shortTitle: work.shortTitle,
+    language: 'en',
+    preferredCitation:
+      work.citations.australian ?? work.citations.nzmj ?? work.citations.apa ?? work.title,
+    neutralCitation: work.citations.nzmj,
+  };
+}
+
+function buildExpression(
+  workUri: string,
+  version: VersionSummary,
+  fallbackState: CanonicalLifecycleState
+): CanonicalExpression {
+  return {
+    expressionUri: buildExpressionUri(workUri, version.version_id),
+    workUri,
+    expressionDate: version.date,
+    publicationDate: version.date,
+    lifecycleState: fallbackState,
+    isCurrent: version.is_current,
+    versionLabel: version.title || version.version_id,
+    language: 'en',
+  };
+}
+
+function buildFallbackExpression(work: Work, workUri: string): CanonicalExpression {
+  return {
+    expressionUri: buildExpressionUri(workUri, work.work_id),
+    workUri,
+    expressionDate: work.date,
+    publicationDate: work.date,
+    inForceDate: work.status === 'in-force' ? work.date : undefined,
+    repealDate: work.status === 'repealed' ? work.date : undefined,
+    lifecycleState: deriveLifecycleState(work.status),
+    isCurrent: true,
+    versionLabel: 'current',
+    language: 'en',
+  };
+}
+
+function buildManifestations(
+  expressions: CanonicalExpression[],
+  versions: VersionSummary[],
+  workUrl?: string
+): CanonicalManifestation[] {
+  const manifestations: CanonicalManifestation[] = [];
+
+  if (versions.length > 0) {
+    versions.forEach((version, index) => {
+      const expression = expressions[index];
+      const formats = version.formats?.length ? version.formats : ['html'];
+
+      formats.forEach(format => {
+        const canonicalFormat = deriveManifestationFormat(format);
+        manifestations.push({
+          manifestationUri: buildManifestationUri(expression.expressionUri, format),
+          expressionUri: expression.expressionUri,
+          format: canonicalFormat,
+          mediaType: deriveMediaType(canonicalFormat),
+        });
+      });
+    });
+
+    return manifestations;
+  }
+
+  const expression = expressions[0];
+  manifestations.push({
+    manifestationUri: buildManifestationUri(expression.expressionUri, 'html'),
+    expressionUri: expression.expressionUri,
+    format: 'html',
+    mediaType: 'text/html',
+    sourceUrl: workUrl,
+  });
+
+  return manifestations;
+}
+
+function buildRelationships(
+  workUri: string,
+  expressions: CanonicalExpression[],
+  manifestations: CanonicalManifestation[]
+): CanonicalRelationship[] {
+  const relationships: CanonicalRelationship[] = [];
+
+  expressions.forEach(expression => {
+    relationships.push({
+      subjectUri: workUri,
+      relationshipType: 'has_expression',
+      objectUri: expression.expressionUri,
+    });
+  });
+
+  manifestations.forEach(manifestation => {
+    relationships.push({
+      subjectUri: manifestation.expressionUri,
+      relationshipType: 'has_manifestation',
+      objectUri: manifestation.manifestationUri,
+    });
+  });
+
+  return relationships;
+}
+
+export function toCanonicalLegislationRecord(work: Work): CanonicalLegislationRecord {
+  const workUri = buildWorkUri(work.jurisdiction, work.work_id);
+  const lifecycleState = deriveLifecycleState(work.status);
+  const expressions =
+    work.versions.length > 0
+      ? work.versions.map(version => buildExpression(workUri, version, lifecycleState))
+      : [buildFallbackExpression(work, workUri)];
+  const manifestations = buildManifestations(expressions, work.versions, work.url);
+
+  return {
+    work: buildCanonicalWork(work, workUri),
+    expressions,
+    manifestations,
+    relationships: buildRelationships(workUri, expressions, manifestations),
+    citations:
+      work.citations.australian || work.citations.nzmj || work.citations.apa
+        ? {
+            preferred:
+              work.citations.australian ?? work.citations.nzmj ?? work.citations.apa ?? work.title,
+            neutral: work.citations.nzmj,
+          }
+        : undefined,
+  };
+}

--- a/src/providers/index.ts
+++ b/src/providers/index.ts
@@ -8,6 +8,7 @@ export * from './legislation-provider.js';
 export * from './nz-provider.js';
 export * from './commonwealth-provider.js';
 export * from './queensland-provider.js';
+export * from './canonical-metadata.js';
 export * from './plugin-loader.js';
 export * from './plugin-discovery.js';
 
@@ -24,9 +25,9 @@ export type {
   ProviderRegistry,
 } from './legislation-provider.js';
 
+import { CommonwealthProvider } from './commonwealth-provider.js';
 import { getGlobalRegistry } from './legislation-provider.js';
 import { NZLegislationProvider } from './nz-provider.js';
-import { CommonwealthProvider } from './commonwealth-provider.js';
 import { QueenslandProvider } from './queensland-provider.js';
 
 /**

--- a/src/providers/output-adapters.ts
+++ b/src/providers/output-adapters.ts
@@ -6,6 +6,7 @@ import type {
   WorkType,
 } from '../models/index.js';
 
+import { toCanonicalLegislationRecord } from './canonical-metadata.js';
 import type {
   SearchResults as ProviderSearchResults,
   VersionSummary,
@@ -106,38 +107,22 @@ export function toLegacySearchResults(results: ProviderSearchResults): LegacySea
     offset: results.offset,
     limit: results.limit,
     links: undefined,
-    results: results.results.map(work => {
-      const metadata = parseWorkIdMetadata(work.work_id);
-      const year = work.year || metadata.year;
-
-      return {
-        id: work.work_id,
-        title: work.title,
-        shortTitle: work.shortTitle,
-        type: normalizeWorkType(work.type || metadata.type),
-        status: normalizeStatus(work.status),
-        date: deriveDate(work.date, year),
-        url: deriveUrl(work.jurisdiction, work.work_id, work.url),
-        versionCount: work.versionCount ?? 0,
-      };
-    }),
+    results: results.results.map(work =>
+      toLegacyWorkFromCanonical(
+        toCanonicalLegislationRecord({
+          ...work,
+          status: work.status ?? 'in-force',
+          versions: [],
+          citations: {},
+        }),
+        work
+      )
+    ),
   };
 }
 
 export function toLegacyWork(work: ProviderWork): LegacyWork {
-  const metadata = parseWorkIdMetadata(work.work_id);
-  const year = work.year || metadata.year;
-
-  return {
-    id: work.work_id,
-    title: work.title,
-    shortTitle: work.shortTitle,
-    type: normalizeWorkType(work.type || metadata.type),
-    status: normalizeStatus(work.status),
-    date: deriveDate(work.date, year),
-    url: deriveUrl(work.jurisdiction, work.work_id, work.url),
-    versionCount: work.versionCount ?? work.versions.length,
-  };
+  return toLegacyWorkFromCanonical(toCanonicalLegislationRecord(work), work);
 }
 
 export function toLegacyVersions(
@@ -152,4 +137,47 @@ export function toLegacyVersions(
     type: version.type ?? fallbackType,
     formats: version.formats ?? [],
   }));
+}
+
+function toLegacyWorkFromCanonical(
+  canonical: ReturnType<typeof toCanonicalLegislationRecord>,
+  fallback: {
+    work_id: string;
+    title: string;
+    shortTitle?: string;
+    type: string;
+    status?: string;
+    date?: string;
+    url?: string;
+    year?: number;
+    versionCount?: number;
+    versions?: VersionSummary[];
+    jurisdiction: string;
+  }
+): LegacyWork {
+  const metadata = parseWorkIdMetadata(fallback.work_id);
+  const year = fallback.year || metadata.year;
+  const currentExpression =
+    canonical.expressions.find(expression => expression.isCurrent) ?? canonical.expressions[0];
+  const primaryManifestation =
+    canonical.manifestations.find(
+      manifestation => manifestation.expressionUri === currentExpression?.expressionUri
+    ) ?? canonical.manifestations[0];
+
+  return {
+    id: fallback.work_id,
+    title: canonical.work.title || fallback.title,
+    shortTitle: canonical.work.shortTitle || fallback.shortTitle,
+    type: normalizeWorkType(canonical.work.documentType || fallback.type || metadata.type),
+    status: normalizeStatus(fallback.status),
+    date: deriveDate(
+      currentExpression?.expressionDate || currentExpression?.publicationDate || fallback.date,
+      year
+    ),
+    url:
+      primaryManifestation?.sourceUrl ||
+      deriveUrl(fallback.jurisdiction, fallback.work_id, fallback.url),
+    versionCount:
+      fallback.versionCount ?? fallback.versions?.length ?? canonical.expressions.length,
+  };
 }

--- a/tests/canonical-legal-metadata.test.ts
+++ b/tests/canonical-legal-metadata.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  CanonicalLegislationRecordSchema,
+  CanonicalLifecycleStateSchema,
+  CanonicalManifestationFormatSchema,
+  CanonicalRelationshipTypeSchema,
+} from '../src/models/canonical.js';
+
+describe('canonical legal metadata schemas', () => {
+  it('accepts a complete canonical legislation record', () => {
+    const parsed = CanonicalLegislationRecordSchema.parse({
+      work: {
+        canonicalId: 'nz:act:2020:67',
+        workUri: 'https://example.test/work/nz/act/2020/67',
+        source: {
+          sourceSystem: 'nz-legislation-api',
+          sourceId: 'act/2020/67',
+          sourceUrl: 'https://www.legislation.govt.nz/act/public/2020/0067/latest/LMS12345.html',
+        },
+        jurisdictionCode: 'nz',
+        documentType: 'act',
+        title: 'Sample Health Act',
+        shortTitle: 'Health Act',
+        preferredCitation: 'Sample Health Act 2020',
+      },
+      expressions: [
+        {
+          expressionUri: 'https://example.test/expression/nz/act/2020/67/2020-08-01',
+          workUri: 'https://example.test/work/nz/act/2020/67',
+          expressionDate: '2020-08-01',
+          publicationDate: '2020-08-01',
+          inForceDate: '2020-08-15',
+          lifecycleState: 'in-force',
+          isCurrent: true,
+          versionLabel: 'latest',
+        },
+      ],
+      manifestations: [
+        {
+          manifestationUri: 'https://example.test/manifestation/nz/act/2020/67/2020-08-01/html',
+          expressionUri: 'https://example.test/expression/nz/act/2020/67/2020-08-01',
+          format: 'html',
+          mediaType: 'text/html',
+          sourceUrl: 'https://www.legislation.govt.nz/act/public/2020/0067/latest/LMS12345.html',
+        },
+      ],
+      relationships: [
+        {
+          subjectUri: 'https://example.test/work/nz/act/2020/67',
+          relationshipType: 'has_expression',
+          objectUri: 'https://example.test/expression/nz/act/2020/67/2020-08-01',
+        },
+      ],
+      citations: {
+        preferred: 'Sample Health Act 2020',
+        neutral: '2020 NZA 67',
+      },
+    });
+
+    expect(parsed.work.language).toBe('en');
+    expect(parsed.expressions[0].language).toBe('en');
+    expect(parsed.relationships).toHaveLength(1);
+  });
+
+  it('rejects invalid lifecycle and relationship values', () => {
+    expect(() => CanonicalLifecycleStateSchema.parse('active')).toThrow();
+    expect(() => CanonicalRelationshipTypeSchema.parse('modifies')).toThrow();
+    expect(() => CanonicalManifestationFormatSchema.parse('epub')).toThrow();
+  });
+});

--- a/tests/canonical-provider-mapping.test.ts
+++ b/tests/canonical-provider-mapping.test.ts
@@ -1,0 +1,94 @@
+import { describe, expect, it } from 'vitest';
+
+import { toCanonicalLegislationRecord } from '../src/providers/canonical-metadata.js';
+import type { Work } from '../src/providers/legislation-provider.js';
+
+describe('canonical provider mapping', () => {
+  it('maps a versioned NZ work into canonical work, expressions, manifestations, and relationships', () => {
+    const work: Work = {
+      work_id: 'act/2020/67',
+      title: 'Health Act 2020',
+      shortTitle: 'Health Act',
+      type: 'act',
+      year: 2020,
+      number: 67,
+      jurisdiction: 'nz',
+      status: 'in-force',
+      date: '2020-08-01',
+      url: 'https://www.legislation.govt.nz/act/public/2020/0067/latest/LMS12345.html',
+      versionCount: 2,
+      versions: [
+        {
+          version_id: 'act/2020/67/2020-08-01',
+          title: 'as enacted',
+          date: '2020-08-01',
+          is_current: false,
+          version: 1,
+          formats: ['html', 'pdf'],
+        },
+        {
+          version_id: 'act/2020/67/2021-05-01',
+          title: 'latest',
+          date: '2021-05-01',
+          is_current: true,
+          version: 2,
+          formats: ['html'],
+        },
+      ],
+      citations: {
+        nzmj: 'Health Act 2020 (NZ)',
+      },
+    };
+
+    const record = toCanonicalLegislationRecord(work);
+
+    expect(record.work.source.sourceSystem).toBe('nz-legislation-api');
+    expect(record.work.canonicalId).toBe('nz:act/2020/67');
+    expect(record.expressions).toHaveLength(2);
+    expect(record.manifestations).toHaveLength(3);
+    expect(
+      record.relationships.filter(
+        relationship => relationship.relationshipType === 'has_expression'
+      )
+    ).toHaveLength(2);
+    expect(record.citations?.preferred).toBe('Health Act 2020 (NZ)');
+  });
+
+  it('creates a fallback current expression when a provider has no versions yet', () => {
+    const work: Work = {
+      work_id: 'act/2021/5',
+      title: 'Act 2021 (Qld)',
+      type: 'act',
+      year: 2021,
+      number: 5,
+      jurisdiction: 'au-qld',
+      status: 'in-force',
+      date: '2021-01-01',
+      url: 'https://www.legislation.qld.gov.au/view/html/inforce/current/act-2021-5',
+      versionCount: 1,
+      versions: [],
+      citations: {
+        australian: 'Act 2021 (Qld)',
+      },
+    };
+
+    const record = toCanonicalLegislationRecord(work);
+
+    expect(record.work.source.sourceSystem).toBe('queensland-legislation-api');
+    expect(record.expressions).toHaveLength(1);
+    expect(record.expressions[0].isCurrent).toBe(true);
+    expect(record.manifestations[0].sourceUrl).toBe(work.url);
+    expect(record.relationships).toEqual([
+      {
+        subjectUri: record.work.workUri,
+        relationshipType: 'has_expression',
+        objectUri: record.expressions[0].expressionUri,
+      },
+      {
+        subjectUri: record.expressions[0].expressionUri,
+        relationshipType: 'has_manifestation',
+        objectUri: record.manifestations[0].manifestationUri,
+      },
+    ]);
+  });
+});

--- a/tests/export-canonical-metadata.test.ts
+++ b/tests/export-canonical-metadata.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from 'vitest';
+
+import { toCanonicalExportRecords } from '../src/commands/export.js';
+import type { SearchResults } from '../src/models/index.js';
+
+describe('export canonical metadata', () => {
+  it('builds additive canonical records from legacy search results', () => {
+    const results: SearchResults = {
+      total: 1,
+      offset: 0,
+      limit: 25,
+      results: [
+        {
+          id: 'act/2020/67',
+          title: 'Health Act 2020',
+          shortTitle: 'Health Act',
+          type: 'act',
+          status: 'in-force',
+          date: '2020-08-01',
+          url: 'https://www.legislation.govt.nz/act/public/2020/0067/latest/LMS12345.html',
+          versionCount: 1,
+        },
+      ],
+      links: undefined,
+    };
+
+    const canonicalRecords = toCanonicalExportRecords(results);
+
+    expect(canonicalRecords).toHaveLength(1);
+    expect(canonicalRecords[0].work.canonicalId).toBe('legacy:act/2020/67');
+    expect(canonicalRecords[0].expressions[0].lifecycleState).toBe('in-force');
+    expect(canonicalRecords[0].manifestations[0].sourceUrl).toBe(results.results[0].url);
+    expect(canonicalRecords[0].relationships.map(r => r.relationshipType)).toEqual([
+      'has_expression',
+      'has_manifestation',
+    ]);
+  });
+});

--- a/tests/legal-metadata-publication.test.ts
+++ b/tests/legal-metadata-publication.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it } from 'vitest';
+
+import type { CanonicalLegislationRecord } from '../src/models/canonical.js';
+import { toSchemaOrgLegislation } from '../src/output/legal-metadata-publication.js';
+
+describe('legal metadata publication', () => {
+  it('projects a canonical record into schema.org legislation JSON-LD', () => {
+    const record: CanonicalLegislationRecord = {
+      work: {
+        canonicalId: 'nz:act/2020/67',
+        workUri: 'urn:nz-legislation:work:nz:act-2020-67',
+        source: {
+          sourceSystem: 'nz-legislation-api',
+          sourceId: 'act/2020/67',
+          sourceUrl: 'https://www.legislation.govt.nz/act/public/2020/0067/latest/LMS12345.html',
+        },
+        jurisdictionCode: 'nz',
+        documentType: 'act',
+        title: 'Health Act 2020',
+        shortTitle: 'Health Act',
+        language: 'en',
+      },
+      expressions: [
+        {
+          expressionUri: 'urn:nz-legislation:work:nz:act-2020-67:expression:2021-05-01',
+          workUri: 'urn:nz-legislation:work:nz:act-2020-67',
+          expressionDate: '2021-05-01',
+          publicationDate: '2021-05-01',
+          lifecycleState: 'in-force',
+          isCurrent: true,
+          versionLabel: 'latest',
+          language: 'en',
+        },
+      ],
+      manifestations: [
+        {
+          manifestationUri:
+            'urn:nz-legislation:work:nz:act-2020-67:expression:2021-05-01:manifestation:html',
+          expressionUri: 'urn:nz-legislation:work:nz:act-2020-67:expression:2021-05-01',
+          format: 'html',
+          mediaType: 'text/html',
+          sourceUrl: 'https://www.legislation.govt.nz/act/public/2020/0067/latest/LMS12345.html',
+        },
+      ],
+      relationships: [],
+    };
+
+    const jsonLd = toSchemaOrgLegislation(record);
+
+    expect(jsonLd['@type']).toBe('Legislation');
+    expect(jsonLd.legislationIdentifier).toBe('nz:act/2020/67');
+    expect(jsonLd.legislationType).toBe('act');
+    expect(jsonLd.url).toBe(record.manifestations[0].sourceUrl);
+    expect(jsonLd.sameAs).toContain(record.work.workUri);
+    expect(jsonLd.sameAs).toContain(record.expressions[0].expressionUri);
+  });
+});

--- a/tests/output-adapters.test.ts
+++ b/tests/output-adapters.test.ts
@@ -1,0 +1,82 @@
+import { describe, expect, it } from 'vitest';
+
+import { toLegacySearchResults, toLegacyWork } from '../src/providers/output-adapters.js';
+import type { SearchResults, Work } from '../src/providers/legislation-provider.js';
+
+describe('output adapters', () => {
+  it('adapts a provider work through the canonical layer without changing legacy shape', () => {
+    const work: Work = {
+      work_id: 'act/2020/67',
+      title: 'Health Act 2020',
+      shortTitle: 'Health Act',
+      type: 'act',
+      year: 2020,
+      number: 67,
+      jurisdiction: 'nz',
+      status: 'in-force',
+      date: '2020-08-01',
+      url: 'https://www.legislation.govt.nz/act/public/2020/0067/latest/LMS12345.html',
+      versionCount: 1,
+      versions: [
+        {
+          version_id: 'act/2020/67/2021-05-01',
+          title: 'latest',
+          date: '2021-05-01',
+          is_current: true,
+          formats: ['html'],
+        },
+      ],
+      citations: {
+        nzmj: 'Health Act 2020 (NZ)',
+      },
+    };
+
+    const legacy = toLegacyWork(work);
+
+    expect(legacy).toEqual({
+      id: 'act/2020/67',
+      title: 'Health Act 2020',
+      shortTitle: 'Health Act',
+      type: 'act',
+      status: 'in-force',
+      date: '2021-05-01',
+      url: 'https://www.legislation.govt.nz/act/public/2020/0067/latest/LMS12345.html',
+      versionCount: 1,
+    });
+  });
+
+  it('adapts provider search summaries through the canonical layer without requiring versions', () => {
+    const results: SearchResults = {
+      total: 1,
+      offset: 0,
+      limit: 25,
+      results: [
+        {
+          work_id: 'act/2021/5',
+          title: 'Act 2021 (Qld)',
+          type: 'act',
+          year: 2021,
+          number: 5,
+          jurisdiction: 'au-qld',
+          status: 'in-force',
+          date: '2021-01-01',
+          url: 'https://www.legislation.qld.gov.au/view/html/inforce/current/act-2021-5',
+          versionCount: 1,
+        },
+      ],
+    };
+
+    const legacy = toLegacySearchResults(results);
+
+    expect(legacy.results[0]).toEqual({
+      id: 'act/2021/5',
+      title: 'Act 2021 (Qld)',
+      shortTitle: undefined,
+      type: 'act',
+      status: 'in-force',
+      date: '2021-01-01',
+      url: 'https://www.legislation.qld.gov.au/view/html/inforce/current/act-2021-5',
+      versionCount: 1,
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- add a standards-aligned canonical legal metadata layer
- map current providers into canonical work, expression, and manifestation records
- wire legacy adapters and metadata exports through canonical metadata additively

## Validation
- pnpm typecheck
- pnpm test:run -- tests/output-adapters.test.ts tests/export-canonical-metadata.test.ts tests/canonical-legal-metadata.test.ts tests/canonical-provider-mapping.test.ts tests/legal-metadata-publication.test.ts
- pnpm exec vale .changeset/fifty-towns-care.md conductor/README.md conductor/status.md conductor/tracks/legal-metadata-standards-alignment/index.md conductor/tracks/legal-metadata-standards-alignment/plan.md conductor/tracks/legal-metadata-standards-alignment/relationship-publication-follow-through.md docs/adr/0004-standards-aligned-canonical-legal-metadata.md docs/developer-guide/architecture.md docs/developer-guide/index.md docs/developer-guide/legal-metadata-standards.md