### PR TITLE
feat: enable Commonwealth prerelease runtime

### DIFF
--- a/.changeset/commonwealth-prerelease-runtime.md
+++ b/.changeset/commonwealth-prerelease-runtime.md
@@ -1,0 +1,8 @@
+---
+'nz-legislation-tool': minor
+---
+
+Enable source-backed prerelease Australian Commonwealth runtime routing for
+search, get-work, versions, export, and MCP paths while keeping citation,
+single-version, stable release, publishing, and registry submission claims
+blocked behind the existing provider gates.

--- a/conductor/tracks.md
+++ b/conductor/tracks.md
@@ -12,19 +12,19 @@ submission, registry, and marketplace gates.
 
 ## Provider implementation tracks
 
-All Australian provider tracks are implementation backlogs only. They do not
-make runtime support release-ready, do not permit publishing or registry
-submission, and must keep unsupported provider capability errors until their
-source-backed gates pass.
+Australian provider tracks do not permit publishing, deployment, registry
+submission, or stable support claims. Commonwealth may run as a source-backed
+prerelease provider inside this repo once its runtime gates pass, but NZ remains
+the only stable support lane until the umbrella release track says otherwise.
 
-| Track                             | Jurisdiction                 | Priority | Current phase                                                               |
-| --------------------------------- | ---------------------------- | -------- | --------------------------------------------------------------------------- |
-| `anz-provider-commonwealth`       | Australian Commonwealth      | P0       | Adapter foundation, source metadata, registry wiring, and runtime-gate work |
-| `anz-provider-queensland`         | Queensland                   | P0       | API access and source-backed adapter                                        |
-| `anz-provider-nsw`                | New South Wales              | P1       | XML/export adapter design                                                   |
-| `anz-provider-victoria`           | Victoria                     | P1       | Source-shape discovery and adapter mapping                                  |
-| `anz-provider-south-australia`    | South Australia              | P1       | Source-shape discovery and adapter mapping                                  |
-| `anz-provider-western-australia`  | Western Australia            | P1       | Source-shape discovery and adapter mapping                                  |
-| `anz-provider-tasmania`           | Tasmania                     | P1       | Source-shape discovery and adapter mapping                                  |
-| `anz-provider-act`                | Australian Capital Territory | P1       | Source-shape discovery and adapter mapping                                  |
-| `anz-provider-northern-territory` | Northern Territory           | P1       | Source-shape discovery and adapter mapping                                  |
+| Track                             | Jurisdiction                 | Priority | Current phase                                                            |
+| --------------------------------- | ---------------------------- | -------- | ------------------------------------------------------------------------ |
+| `anz-provider-commonwealth`       | Australian Commonwealth      | P0       | Source-backed prerelease runtime wiring, provenance, fixtures, and gates |
+| `anz-provider-queensland`         | Queensland                   | P0       | API access and source-backed adapter                                     |
+| `anz-provider-nsw`                | New South Wales              | P1       | XML/export adapter design                                                |
+| `anz-provider-victoria`           | Victoria                     | P1       | Source-shape discovery and adapter mapping                               |
+| `anz-provider-south-australia`    | South Australia              | P1       | Source-shape discovery and adapter mapping                               |
+| `anz-provider-western-australia`  | Western Australia            | P1       | Source-shape discovery and adapter mapping                               |
+| `anz-provider-tasmania`           | Tasmania                     | P1       | Source-shape discovery and adapter mapping                               |
+| `anz-provider-act`                | Australian Capital Territory | P1       | Source-shape discovery and adapter mapping                               |
+| `anz-provider-northern-territory` | Northern Territory           | P1       | Source-shape discovery and adapter mapping                               |

--- a/conductor/tracks/anz-platform-release-and-distribution/plan.md
+++ b/conductor/tracks/anz-platform-release-and-distribution/plan.md
@@ -41,13 +41,14 @@
 
 ## Phase 3: Provider truthfulness
 
-**Status:** Blocked until provider capability work is implemented.
+**Status:** In progress for Commonwealth prerelease runtime; blocked for stable
+Australian release claims and remaining jurisdictions.
 
 - Use `provider-api-roadmap.md` as the concrete source-validation backlog for
   legal-data providers and APIs.
 - Remove or quarantine placeholder Australian legal-data behavior.
-- Add structured unsupported capability errors.
-- Add no-placeholder legal-data tests.
+- Add structured unsupported capability errors for incomplete provider features.
+- Add no-placeholder legal-data tests for Commonwealth runtime fixtures.
 - Confirm Australian support is described only as prerelease until the gate
   passes.
 - Prioritize Australian Commonwealth and Queensland provider replacement before
@@ -56,21 +57,22 @@
 
 ## Phase 4: Capability manifest
 
-**Status:** Not started.
+**Status:** In progress.
 
-- Implement a provider capability manifest.
-- Use the manifest in CLI, MCP, export metadata, docs, and website surfaces.
-- Add tests that fail on manifest/provider mismatch.
+- [x] Implement a provider capability manifest.
+- [~] Use the manifest in CLI, MCP, export metadata, docs, and website surfaces.
+- [~] Add tests that fail on manifest/provider mismatch.
 - Require every listing or install page to match manifest-backed claims.
 
 ## Phase 5: MCP and export hardening
 
 **Status:** In progress. Runtime gates now block unsupported providers through
-the provider registry; provenance and install-snippet verification remain.
+the provider registry; Commonwealth prerelease runtime and provenance are being
+wired while install-snippet verification remains.
 
 - [x] Route MCP tools through provider-aware capability checks.
 - [x] Route export paths through provider-aware capability checks.
-- [ ] Add provider/source cards and provenance metadata.
+- [~] Add provider/source cards and provenance metadata.
 - [ ] Use `docs/maintainers/provenance-wiring-test-plan.md` as the future
       provenance test checklist before emitting source cards in export or MCP
       outputs.

--- a/conductor/tracks/anz-provider-commonwealth/plan.md
+++ b/conductor/tracks/anz-provider-commonwealth/plan.md
@@ -24,23 +24,24 @@
 
 ## Phase 2: Provider-aware CLI, MCP, and export
 
-**Status:** In progress. Shared runtime gates now block unsupported providers;
-Commonwealth provider selection and provenance output are still not enabled.
+**Status:** In progress. Commonwealth search, get-work, versions, export, and
+MCP are being enabled as source-backed prerelease runtime paths. Citation and
+single-version support remain blocked.
 
-- [ ] Route Commonwealth CLI paths through jurisdiction-aware provider
-      selection.
-- [x] Route Commonwealth MCP/export unsupported paths through shared runtime
-      provider gates.
-- [ ] Add source cards and provenance metadata to export output.
-- [ ] Preserve structured unsupported errors for incomplete features.
+- [~] Route Commonwealth CLI paths through jurisdiction-aware provider
+  selection.
+- [~] Route Commonwealth MCP/export paths through shared runtime provider
+  gates.
+- [~] Add source cards and provenance metadata to export and MCP output.
+- [x] Preserve structured unsupported errors for incomplete features.
 
 ## Phase 3: Tests and gates
 
 **Status:** In progress.
 
 - [x] Add unit tests for mapper, adapter, and unsupported runtime cases.
-- [ ] Add unit tests for provenance output.
-- [ ] Add no-placeholder legal-data tests for Commonwealth fixtures.
+- [~] Add unit tests for provenance output.
+- [~] Add no-placeholder legal-data tests for Commonwealth fixtures.
 - [ ] Add opt-in live smoke tests that are rate-limit respectful.
 - [ ] Keep `pnpm typecheck`, `pnpm test:run`, `pnpm build`, and
       `pnpm gate:no-placeholder-legal-data` passing.

--- a/conductor/tracks/anz-provider-commonwealth/spec.md
+++ b/conductor/tracks/anz-provider-commonwealth/spec.md
@@ -2,9 +2,10 @@
 
 ## Purpose
 
-Implement Australian Commonwealth legislation support from the official Federal
-Register of Legislation API inside this repository, without changing the stable
-New Zealand support contract or enabling unsupported Australian runtime claims.
+Implement prerelease Australian Commonwealth legislation support from the
+official Federal Register of Legislation API inside this repository, without
+changing the stable New Zealand support contract or enabling unsupported
+Australian stable-release claims.
 
 ## Requirements
 
@@ -22,15 +23,16 @@ transition aliases while Australian support is incomplete.
 
 ### R3: Capability gate
 
-`au-commonwealth` must remain unsupported in the provider capability manifest
-until search, get-work, versions, citation, export, MCP, source cards,
-documentation, and no-placeholder tests all pass.
+`au-commonwealth` may be marked prerelease/source-backed for search, get-work,
+versions, export, and MCP only after provider-aware runtime routing, source
+cards, and no-placeholder tests pass. Citation and single-version support remain
+unsupported until they have source-backed mappings.
 
 ### R4: Provider-aware runtime
 
-When enabled later, CLI, MCP, and export paths must route through explicit
-jurisdiction/provider selection and must never fall back to New Zealand data for
-Commonwealth requests.
+CLI, MCP, and export paths must route through explicit jurisdiction/provider
+selection and must never fall back to New Zealand data for Commonwealth
+requests.
 
 ### R5: Provenance
 
@@ -44,4 +46,5 @@ versions, document URLs, and retrieval metadata.
 - submitting registry listings
 - renaming the repository or package
 - starting a Rust rewrite
-- enabling live Commonwealth runtime support before the release gates pass
+- promoting Commonwealth runtime support beyond prerelease before the release
+  gates pass

--- a/scripts/check-no-placeholder-legal-data.ts
+++ b/scripts/check-no-placeholder-legal-data.ts
@@ -6,6 +6,13 @@ import {
 const placeholderTerms = /\b(dummy|fake|lorem|placeholder|sample)\b/i;
 
 const failures: string[] = [];
+const allowedAustralianSourceBackedFeatures = new Set([
+  'au-commonwealth.search',
+  'au-commonwealth.getWork',
+  'au-commonwealth.getVersions',
+  'au-commonwealth.export',
+  'au-commonwealth.mcp',
+]);
 
 function assertNoPlaceholderText(capability: ProviderCapability): void {
   const fields = [
@@ -43,9 +50,14 @@ for (const capability of getProviderCapabilities()) {
       );
     }
 
-    if (capability.jurisdiction.startsWith('au-') && feature.sourceBacked) {
+    const featureKey = `${capability.jurisdiction}.${featureName}`;
+    if (
+      capability.jurisdiction.startsWith('au-') &&
+      feature.sourceBacked &&
+      !allowedAustralianSourceBackedFeatures.has(featureKey)
+    ) {
       failures.push(
-        `${capability.jurisdiction}.${featureName}: Australian providers must remain unbacked until source validation lands`
+        `${featureKey}: Australian providers must remain unbacked until source validation lands`
       );
     }
   }

--- a/src/client.ts
+++ b/src/client.ts
@@ -19,7 +19,14 @@ import {
   type SearchResults,
   type Version,
   type Work,
+  type LegislationStatus,
+  type WorkType,
 } from './models/index.js';
+import type { JurisdictionCode } from './providers/capability-manifest.js';
+import {
+  createCommonwealthProviderAdapter,
+  type CommonwealthProviderAdapter,
+} from './providers/commonwealth.js';
 import { logger } from './utils/logger.js';
 
 /**
@@ -93,6 +100,18 @@ interface HttpClientLike {
 }
 
 type HttpClientFactory = () => HttpClientLike;
+type CommonwealthProviderAdapterFactory = () => CommonwealthProviderAdapter;
+
+export interface ProviderAwareSearchParams {
+  query?: string;
+  type?: string;
+  status?: string;
+  from?: string;
+  to?: string;
+  limit?: number;
+  offset?: number;
+  jurisdiction?: JurisdictionCode;
+}
 
 /**
  * Generate cache key from request parameters
@@ -336,9 +355,21 @@ function createClient(): HttpClientLike {
 }
 
 let httpClientFactory: HttpClientFactory = createClient;
+let commonwealthProviderAdapterFactory: CommonwealthProviderAdapterFactory =
+  createCommonwealthProviderAdapter;
 
 export function setHttpClientFactoryForTesting(factory?: HttpClientFactory): void {
   httpClientFactory = factory ?? createClient;
+}
+
+export function setCommonwealthProviderAdapterFactoryForTesting(
+  factory?: CommonwealthProviderAdapterFactory
+): void {
+  commonwealthProviderAdapterFactory = factory ?? createCommonwealthProviderAdapter;
+}
+
+function getJurisdiction(params?: { jurisdiction?: JurisdictionCode }): JurisdictionCode {
+  return params?.jurisdiction ?? 'nz';
 }
 
 async function getWorkFromVersions(
@@ -379,7 +410,18 @@ export async function searchWorks(params: {
   to?: string;
   limit?: number;
   offset?: number;
+  jurisdiction?: JurisdictionCode;
 }): Promise<SearchResults> {
+  if (getJurisdiction(params) === 'au-commonwealth') {
+    return commonwealthProviderAdapterFactory().searchWorks({
+      query: params.query,
+      type: params.type as WorkType | undefined,
+      status: params.status as LegislationStatus | undefined,
+      limit: params.limit,
+      offset: params.offset,
+    });
+  }
+
   const cacheKey = generateCacheKey('search', params as Record<string, string>);
 
   // Try cache first
@@ -447,8 +489,15 @@ export async function searchWorks(params: {
 /**
  * Get a specific work by ID
  */
-export async function getWork(workId: string): Promise<Work> {
-  const cacheKey = generateCacheKey('work', { id: workId });
+export async function getWork(
+  workId: string,
+  options: { jurisdiction?: JurisdictionCode } = {}
+): Promise<Work> {
+  if (getJurisdiction(options) === 'au-commonwealth') {
+    return commonwealthProviderAdapterFactory().getWork(workId);
+  }
+
+  const cacheKey = generateCacheKey('work', { id: workId, jurisdiction: getJurisdiction(options) });
 
   // Try cache first
   const cached = getFromCache<Work>(cacheKey);
@@ -545,8 +594,15 @@ export async function getWork(workId: string): Promise<Work> {
 /**
  * Get all versions of a work
  */
-export async function getWorkVersions(workId: string): Promise<Version[]> {
-  const cacheKey = generateCacheKey('versions', { workId });
+export async function getWorkVersions(
+  workId: string,
+  options: { jurisdiction?: JurisdictionCode } = {}
+): Promise<Version[]> {
+  if (getJurisdiction(options) === 'au-commonwealth') {
+    return commonwealthProviderAdapterFactory().getWorkVersions(workId);
+  }
+
+  const cacheKey = generateCacheKey('versions', { workId, jurisdiction: getJurisdiction(options) });
 
   // Try cache first
   const cached = getFromCache<Version[]>(cacheKey);

--- a/src/commands/export.ts
+++ b/src/commands/export.ts
@@ -12,6 +12,7 @@ import { worksToCsv } from '../output/index.js';
 import { ProviderCapabilityError } from '../providers/capability-manifest.js';
 import { parseJurisdictionCode } from '../providers/jurisdictions.js';
 import { assertRuntimeProviderSupported } from '../providers/runtime.js';
+import { getProviderSourceCard } from '../providers/source-cards.js';
 
 interface ExportOptions {
   query: string;
@@ -45,6 +46,7 @@ export const exportCommand = new Command()
     try {
       const limit = Math.min(parseInt(options.limit, 10), 1000);
       const jurisdiction = parseJurisdictionCode(options.jurisdiction);
+      const sourceCard = getProviderSourceCard(jurisdiction);
 
       assertRuntimeProviderSupported(jurisdiction, 'export');
 
@@ -55,6 +57,7 @@ export const exportCommand = new Command()
         from: options.from,
         to: options.to,
         limit,
+        jurisdiction,
       });
 
       spinner.stop();
@@ -76,6 +79,7 @@ export const exportCommand = new Command()
                 },
                 timestamp,
                 jurisdiction,
+                sourceCard,
                 totalResults: results.total,
                 exportedCount: results.results.length,
               },
@@ -93,6 +97,9 @@ export const exportCommand = new Command()
           csvContent += `\n# Query: ${options.query}`;
           csvContent += `\n# Timestamp: ${timestamp}`;
           csvContent += `\n# Jurisdiction: ${jurisdiction}`;
+          csvContent += `\n# Provider: ${sourceCard.providerId}`;
+          csvContent += `\n# Source Authority: ${sourceCard.sourceAuthority}`;
+          csvContent += `\n# Release Channel: ${sourceCard.releaseChannel}`;
           csvContent += `\n# Total Results: ${results.total}`;
           csvContent += `\n# Exported: ${results.results.length}`;
           if (options.type) {

--- a/src/commands/get.ts
+++ b/src/commands/get.ts
@@ -7,12 +7,14 @@ import ora from 'ora';
 
 import { getWork, getWorkVersions } from '../client.js';
 import { printWorkDetail, printVersionsTable, printJson, versionsToCsv } from '../output/index.js';
+import { parseJurisdictionCode } from '../providers/jurisdictions.js';
 import { logger } from '../utils/logger.js';
 import { validateWorkId, sanitizeInput } from '../utils/validation.js';
 
 interface GetOptions {
   versions?: boolean;
   format: string;
+  jurisdiction: string;
 }
 
 export const getCommand = new Command()
@@ -21,6 +23,7 @@ export const getCommand = new Command()
   .argument('<id>', 'Work ID (e.g., act_public_1989_18)')
   .option('--versions', 'Show version history')
   .option('--format <format>', 'Output format (table, json, csv)', 'table')
+  .option('-j, --jurisdiction <code>', 'Jurisdiction provider (default: nz)', 'nz')
   .action(async (workId: string, options: GetOptions) => {
     const spinner = ora('Retrieving legislation...').start();
 
@@ -41,10 +44,11 @@ export const getCommand = new Command()
       }
 
       logger.debug('Work ID validated', { workId: sanitizedWorkId });
+      const jurisdiction = parseJurisdictionCode(options.jurisdiction);
 
       if (options.versions) {
         // Get version history
-        const versions = await getWorkVersions(sanitizedWorkId);
+        const versions = await getWorkVersions(sanitizedWorkId, { jurisdiction });
         spinner.stop();
 
         switch (options.format.toLowerCase()) {
@@ -61,7 +65,7 @@ export const getCommand = new Command()
         }
       } else {
         // Get work details
-        const work = await getWork(sanitizedWorkId);
+        const work = await getWork(sanitizedWorkId, { jurisdiction });
         spinner.stop();
 
         switch (options.format.toLowerCase()) {

--- a/src/commands/search.ts
+++ b/src/commands/search.ts
@@ -7,6 +7,7 @@ import ora from 'ora';
 
 import { searchWorks } from '../client.js';
 import { printTable, printJson, worksToCsv } from '../output/index.js';
+import { parseJurisdictionCode } from '../providers/jurisdictions.js';
 import { logger } from '../utils/logger.js';
 import { validateSearchParams, sanitizeInput } from '../utils/validation.js';
 
@@ -19,6 +20,7 @@ interface SearchOptions {
   limit: string;
   offset: string;
   format: string;
+  jurisdiction: string;
 }
 
 export const searchCommand = new Command()
@@ -32,6 +34,7 @@ export const searchCommand = new Command()
   .option('-l, --limit <number>', 'Maximum results (default: 25, max: 100)', '25')
   .option('-o, --offset <number>', 'Result offset for pagination', '0')
   .option('--format <format>', 'Output format (table, json, csv)', 'table')
+  .option('-j, --jurisdiction <code>', 'Jurisdiction provider (default: nz)', 'nz')
   .action(async (options: SearchOptions) => {
     const spinner = ora('Searching legislation...').start();
 
@@ -59,10 +62,12 @@ export const searchCommand = new Command()
       }
 
       const validatedParams = validation.data;
+      const jurisdiction = parseJurisdictionCode(options.jurisdiction);
       logger.debug('Search parameters validated', {
         query: validatedParams.query,
         type: validatedParams.type,
         limit: validatedParams.limit,
+        jurisdiction,
       });
 
       const results = await searchWorks({
@@ -73,6 +78,7 @@ export const searchCommand = new Command()
         to: validatedParams.to,
         limit: validatedParams.limit,
         offset: validatedParams.offset,
+        jurisdiction,
       });
 
       spinner.stop();

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -17,6 +17,7 @@ import {
 } from '../providers/capability-manifest.js';
 import { jurisdictionCodes } from '../providers/jurisdictions.js';
 import { getUnsupportedRuntimeProviderCapability } from '../providers/runtime.js';
+import { getProviderSourceCard } from '../providers/source-cards.js';
 import { logger } from '../utils/logger.js';
 
 /**
@@ -78,6 +79,12 @@ function createMcpErrorResponse(text: string): McpTextToolResponse {
       },
     ],
   };
+}
+
+function sourceCardText(jurisdiction: JurisdictionCode): string {
+  const card = getProviderSourceCard(jurisdiction);
+
+  return `\n\nSource: ${card.sourceAuthority} (${card.providerId}, ${card.releaseChannel})`;
 }
 
 /**
@@ -164,6 +171,7 @@ function registerSearchTool(server: McpServer): void {
           from: params.from,
           to: params.to,
           limit: params.limit,
+          jurisdiction: params.jurisdiction,
         });
 
         return {
@@ -177,7 +185,8 @@ function registerSearchTool(server: McpServer): void {
                     work =>
                       `• **${work.title}** (${work.type}, ${work.status})\n  ID: ${work.id}\n  Date: ${work.date}`
                   )
-                  .join('\n\n'),
+                  .join('\n\n') +
+                sourceCardText(params.jurisdiction),
             },
           ],
         };
@@ -213,7 +222,7 @@ function registerGetTool(server: McpServer): void {
           return createMcpErrorResponse('MCP rate limit exceeded. Please try again later.');
         }
 
-        const work = await getWork(params.workId);
+        const work = await getWork(params.workId, { jurisdiction: params.jurisdiction });
 
         return {
           content: [
@@ -227,7 +236,8 @@ function registerGetTool(server: McpServer): void {
                 `• **Date:** ${work.date}\n` +
                 `• **Versions:** ${work.versionCount}\n` +
                 `• **URL:** ${work.url}` +
-                (work.shortTitle ? `\n• **Short Title:** ${work.shortTitle}` : ''),
+                (work.shortTitle ? `\n• **Short Title:** ${work.shortTitle}` : '') +
+                sourceCardText(params.jurisdiction),
             },
           ],
         };
@@ -263,7 +273,9 @@ function registerGetVersionsTool(server: McpServer): void {
           return createMcpErrorResponse('MCP rate limit exceeded. Please try again later.');
         }
 
-        const versions = await getWorkVersions(params.workId);
+        const versions = await getWorkVersions(params.workId, {
+          jurisdiction: params.jurisdiction,
+        });
 
         return {
           content: [
@@ -279,7 +291,8 @@ function registerGetVersionsTool(server: McpServer): void {
                       `Current: ${v.isCurrent ? 'Yes' : 'No'}\n  ` +
                       `Formats: ${v.formats.join(', ')}`
                   )
-                  .join('\n\n'),
+                  .join('\n\n') +
+                sourceCardText(params.jurisdiction),
             },
           ],
         };
@@ -319,7 +332,7 @@ function registerCitationTool(server: McpServer): void {
           return createMcpErrorResponse('MCP rate limit exceeded. Please try again later.');
         }
 
-        const work = await getWork(params.workId);
+        const work = await getWork(params.workId, { jurisdiction: params.jurisdiction });
         const citation = generateCitation(work, params.style);
 
         return {
@@ -367,6 +380,7 @@ function registerExportTool(server: McpServer): void {
         const results = await searchWorks({
           query: params.query,
           limit: params.limit,
+          jurisdiction: params.jurisdiction,
         });
 
         if (params.format === 'json') {
@@ -374,7 +388,14 @@ function registerExportTool(server: McpServer): void {
             content: [
               {
                 type: 'text',
-                text: JSON.stringify(results, null, 2),
+                text: JSON.stringify(
+                  {
+                    sourceCard: getProviderSourceCard(params.jurisdiction),
+                    results,
+                  },
+                  null,
+                  2
+                ),
               },
             ],
           };
@@ -384,7 +405,7 @@ function registerExportTool(server: McpServer): void {
             content: [
               {
                 type: 'text',
-                text: `**CSV Export** (${results.results.length} results)\nHeaders: id, title, shortTitle, type, status, date, url, versionCount\n\n\`\`\`csv\n${csv}\n\`\`\``,
+                text: `**CSV Export** (${results.results.length} results)${sourceCardText(params.jurisdiction)}\nHeaders: id, title, shortTitle, type, status, date, url, versionCount\n\n\`\`\`csv\n${csv}\n\`\`\``,
               },
             ],
           };

--- a/src/providers/capability-manifest.ts
+++ b/src/providers/capability-manifest.ts
@@ -69,11 +69,17 @@ const unsupportedAuFeature: FeatureCapability = {
     'Source validation and provider implementation are required before this feature can be enabled.',
 };
 
-const validatedCommonwealthFeature: FeatureCapability = {
+const supportedCommonwealthPrereleaseFeature: FeatureCapability = {
+  status: 'supported',
+  sourceBacked: true,
+  notes: 'Prerelease support backed by the Federal Register of Legislation public API.',
+};
+
+const unsupportedCommonwealthFeature: FeatureCapability = {
   status: 'unsupported',
   sourceBacked: false,
   notes:
-    'Source validation is complete against the Federal Register of Legislation API; provider implementation is required before this feature can be enabled.',
+    'Federal Register mapping for this feature is not complete; use structured unsupported capability errors.',
 };
 
 const cloneFeature = (capability: FeatureCapability): FeatureCapability => ({ ...capability });
@@ -102,8 +108,16 @@ export const providerCapabilityManifest: readonly ProviderCapability[] = [
     label: 'Australian Commonwealth',
     providerId: 'federal-register-of-legislation',
     sourceAuthority: 'Federal Register of Legislation public API',
-    releaseChannel: 'planned',
-    features: features(validatedCommonwealthFeature),
+    releaseChannel: 'prerelease',
+    features: {
+      search: cloneFeature(supportedCommonwealthPrereleaseFeature),
+      getWork: cloneFeature(supportedCommonwealthPrereleaseFeature),
+      getVersions: cloneFeature(supportedCommonwealthPrereleaseFeature),
+      getVersion: cloneFeature(unsupportedCommonwealthFeature),
+      citation: cloneFeature(unsupportedCommonwealthFeature),
+      export: cloneFeature(supportedCommonwealthPrereleaseFeature),
+      mcp: cloneFeature(supportedCommonwealthPrereleaseFeature),
+    },
   },
   {
     jurisdiction: 'au-qld',

--- a/src/providers/commonwealth.ts
+++ b/src/providers/commonwealth.ts
@@ -1,3 +1,5 @@
+import got from 'got';
+
 import type { LegislationStatus, SearchResults, Version, Work, WorkType } from '../models/index.js';
 
 export const COMMONWEALTH_API_BASE_URL = 'https://api.prod.legislation.gov.au/v1';
@@ -69,7 +71,7 @@ export interface CommonwealthProviderSource {
   sourceAuthority: 'Federal Register of Legislation public API';
   apiBaseUrl: typeof COMMONWEALTH_API_BASE_URL;
   registerBaseUrl: typeof COMMONWEALTH_REGISTER_BASE_URL;
-  runtimeEnabled: false;
+  runtimeEnabled: boolean;
 }
 
 export interface CommonwealthProviderAdapter {
@@ -90,8 +92,24 @@ export const commonwealthProviderSource: CommonwealthProviderSource = {
   sourceAuthority: 'Federal Register of Legislation public API',
   apiBaseUrl: COMMONWEALTH_API_BASE_URL,
   registerBaseUrl: COMMONWEALTH_REGISTER_BASE_URL,
-  runtimeEnabled: false,
+  runtimeEnabled: true,
 };
+
+export function createCommonwealthHttpClient(): CommonwealthHttpClientLike {
+  return got.extend({
+    prefixUrl: COMMONWEALTH_API_BASE_URL,
+    timeout: { request: 30000 },
+    headers: {
+      Accept: 'application/json',
+      'User-Agent': 'nz-legislation-tool/1.0.0 prerelease-commonwealth-provider',
+    },
+    retry: {
+      limit: 2,
+      methods: ['get'],
+      statusCodes: [408, 429, 500, 502, 503, 504],
+    },
+  });
+}
 
 function toDateOnly(value?: string | null): string {
   const trimmed = value?.trim();
@@ -371,15 +389,7 @@ export function createCommonwealthProviderAdapter(
 ): CommonwealthProviderAdapter {
   const providerClient =
     dependencies.providerClient ??
-    (dependencies.httpClient
-      ? createCommonwealthProviderClient(dependencies.httpClient)
-      : undefined);
-
-  if (!providerClient) {
-    throw new Error(
-      'Commonwealth provider adapter requires either a providerClient or an httpClient'
-    );
-  }
+    createCommonwealthProviderClient(dependencies.httpClient ?? createCommonwealthHttpClient());
 
   return {
     source: commonwealthProviderSource,

--- a/src/providers/registry.ts
+++ b/src/providers/registry.ts
@@ -5,7 +5,10 @@ import {
 } from './capability-manifest.js';
 import { commonwealthProviderSource, type CommonwealthProviderSource } from './commonwealth.js';
 
-export type ProviderRuntimeKind = 'legacy-nz-client' | 'gated-au-adapter' | 'planned-au-provider';
+export type ProviderRuntimeKind =
+  | 'legacy-nz-client'
+  | 'prerelease-au-adapter'
+  | 'planned-au-provider';
 
 export interface ProviderRegistryEntry {
   readonly jurisdiction: JurisdictionCode;
@@ -22,7 +25,7 @@ function runtimeKindForCapability(capability: ProviderCapability): ProviderRunti
   }
 
   if (capability.jurisdiction === commonwealthProviderSource.jurisdiction) {
-    return 'gated-au-adapter';
+    return 'prerelease-au-adapter';
   }
 
   return 'planned-au-provider';
@@ -45,7 +48,10 @@ function registryEntryForCapability(capability: ProviderCapability): ProviderReg
     jurisdiction: capability.jurisdiction,
     providerId: capability.providerId,
     runtimeKind,
-    runtimeSupported: capability.releaseChannel === 'stable' && capability.jurisdiction === 'nz',
+    runtimeSupported:
+      capability.jurisdiction === 'nz' ||
+      (capability.jurisdiction === commonwealthProviderSource.jurisdiction &&
+        capability.releaseChannel === 'prerelease'),
     capability,
     source: sourceForCapability(capability),
   };

--- a/src/providers/source-cards.ts
+++ b/src/providers/source-cards.ts
@@ -33,7 +33,7 @@ export interface ProviderSourceBackedFeatureSummary {
 export interface ProviderSourceMetadata {
   readonly apiBaseUrl?: string;
   readonly registerBaseUrl?: string;
-  readonly runtimeEnabled?: false;
+  readonly runtimeEnabled?: boolean;
 }
 
 export interface ProviderSourceCard {

--- a/src/utils/validation.ts
+++ b/src/utils/validation.ts
@@ -23,8 +23,8 @@ export const WorkIdSchema = z
   .string()
   .min(1, 'Work ID is required')
   .regex(
-    /^(?:[a-z0-9-]+(?:_[a-z0-9-]+){2,}|[a-z0-9-]+\/\d{4}\/\d+)$/,
-    'Invalid work ID format. Expected an API work ID like act_public_1989_18.'
+    /^(?:[a-z0-9-]+(?:_[a-z0-9-]+){2,}|[a-z0-9-]+\/\d{4}\/\d+|[A-Z]\d{4}[A-Z]\d{5})$/,
+    'Invalid work ID format. Expected an API work ID like act_public_1989_18 or C2004A01224.'
   );
 
 /**

--- a/tests/client.test.ts
+++ b/tests/client.test.ts
@@ -3,7 +3,9 @@ import {
   clearCache,
   getRateLimitStatus,
   getWork,
+  getWorkVersions,
   searchWorks,
+  setCommonwealthProviderAdapterFactoryForTesting,
   setHttpClientFactoryForTesting,
 } from '../src/client.ts';
 import { ErrorCode } from '../src/errors.ts';
@@ -21,6 +23,7 @@ function makeHttpError(statusCode: number, message: string, url: string) {
 afterEach(() => {
   clearCache();
   setHttpClientFactoryForTesting();
+  setCommonwealthProviderAdapterFactoryForTesting();
 });
 
 describe('Rate Limiting', () => {
@@ -43,6 +46,87 @@ describe('Rate Limiting', () => {
 });
 
 describe('Client error handling', () => {
+  it('routes Commonwealth requests through the prerelease provider adapter', async () => {
+    const calls: string[] = [];
+
+    setCommonwealthProviderAdapterFactoryForTesting(() => ({
+      source: {
+        jurisdiction: 'au-commonwealth',
+        providerId: 'federal-register-of-legislation',
+        sourceAuthority: 'Federal Register of Legislation public API',
+        apiBaseUrl: 'https://api.prod.legislation.gov.au/v1',
+        registerBaseUrl: 'https://www.legislation.gov.au',
+        runtimeEnabled: true,
+      },
+      async searchWorks(params) {
+        calls.push(`search:${params.query ?? ''}`);
+
+        return {
+          total: 1,
+          offset: 0,
+          limit: 20,
+          results: [
+            {
+              id: 'C2004A01224',
+              title: 'Legislation Act 2003',
+              shortTitle: undefined,
+              type: 'act',
+              status: 'in-force',
+              date: '2003-12-17',
+              url: 'https://www.legislation.gov.au/C2004A01224/latest/text',
+              versionCount: 1,
+            },
+          ],
+          links: undefined,
+        };
+      },
+      async getWork(workId) {
+        calls.push(`get:${workId}`);
+
+        return {
+          id: workId,
+          title: 'Legislation Act 2003',
+          shortTitle: undefined,
+          type: 'act',
+          status: 'in-force',
+          date: '2003-12-17',
+          url: 'https://www.legislation.gov.au/C2004A01224/latest/text',
+          versionCount: 1,
+        };
+      },
+      async getWorkVersions(workId) {
+        calls.push(`versions:${workId}`);
+
+        return [
+          {
+            id: 'C2004A01224',
+            version: 1,
+            date: '2005-01-01',
+            isCurrent: true,
+            type: 'InForce',
+            formats: ['https://www.legislation.gov.au/C2004A01224/latest/text'],
+          },
+        ];
+      },
+    }));
+
+    await expect(
+      searchWorks({ query: 'Legislation Act', jurisdiction: 'au-commonwealth' })
+    ).resolves.toMatchObject({
+      results: [{ id: 'C2004A01224' }],
+    });
+    await expect(
+      getWork('C2004A01224', { jurisdiction: 'au-commonwealth' })
+    ).resolves.toMatchObject({
+      id: 'C2004A01224',
+    });
+    await expect(
+      getWorkVersions('C2004A01224', { jurisdiction: 'au-commonwealth' })
+    ).resolves.toHaveLength(1);
+
+    expect(calls).toEqual(['search:Legislation Act', 'get:C2004A01224', 'versions:C2004A01224']);
+  });
+
   it('should reconstruct a work from the versions endpoint when the direct work endpoint returns 404', async () => {
     setHttpClientFactoryForTesting(() => ({
       get: (url: string) => ({

--- a/tests/commonwealth-provider-adapter.test.ts
+++ b/tests/commonwealth-provider-adapter.test.ts
@@ -82,7 +82,7 @@ function createMockHttpClient(responses: Record<string, unknown>): {
 }
 
 describe('Commonwealth provider adapter', () => {
-  it('declares source metadata without enabling Australian runtime support', () => {
+  it('declares source metadata for prerelease Australian runtime support', () => {
     const unsupportedSearch = getUnsupportedProviderCapability('au-commonwealth', 'search');
 
     expect(commonwealthProviderSource).toEqual({
@@ -91,13 +91,9 @@ describe('Commonwealth provider adapter', () => {
       sourceAuthority: 'Federal Register of Legislation public API',
       apiBaseUrl: 'https://api.prod.legislation.gov.au/v1',
       registerBaseUrl: 'https://www.legislation.gov.au',
-      runtimeEnabled: false,
+      runtimeEnabled: true,
     });
-    expect(unsupportedSearch).toMatchObject({
-      status: 'unsupported',
-      sourceBacked: false,
-      providerId: 'federal-register-of-legislation',
-    });
+    expect(unsupportedSearch).toBeNull();
   });
 
   it('uses the existing Commonwealth client for search, title, and versions lookups', async () => {
@@ -195,7 +191,7 @@ describe('Commonwealth provider adapter', () => {
 
     const adapter = createCommonwealthProviderAdapter({ providerClient });
 
-    expect(adapter.source.runtimeEnabled).toBe(false);
+    expect(adapter.source.runtimeEnabled).toBe(true);
 
     await expect(adapter.searchWorks({ query: 'Legislation Act' })).resolves.toMatchObject({
       results: [],
@@ -213,9 +209,7 @@ describe('Commonwealth provider adapter', () => {
     ]);
   });
 
-  it('fails closed when no client dependency is provided', () => {
-    expect(() => createCommonwealthProviderAdapter()).toThrow(
-      'Commonwealth provider adapter requires either a providerClient or an httpClient'
-    );
+  it('creates a default HTTP-backed adapter when no client dependency is provided', () => {
+    expect(createCommonwealthProviderAdapter().source).toBe(commonwealthProviderSource);
   });
 });

--- a/tests/e2e/cli.test.ts
+++ b/tests/e2e/cli.test.ts
@@ -128,7 +128,8 @@ describe('E2E CLI Tests', () => {
       });
       expect(auCommonwealthRuntimeProvider).toMatchObject({
         jurisdiction: 'au-commonwealth',
-        runtimeSupported: false,
+        runtimeSupported: true,
+        runtimeKind: 'prerelease-au-adapter',
       });
     });
   });

--- a/tests/provider-capability-manifest.test.ts
+++ b/tests/provider-capability-manifest.test.ts
@@ -72,8 +72,10 @@ describe('provider capability manifest', () => {
     expect(getProviderCapability('nz').features.search.status).toBe('supported');
   });
 
-  it('keeps Australian providers blocked until source-backed provider work lands', () => {
-    for (const jurisdiction of australianJurisdictions) {
+  it('keeps planned Australian providers blocked until source-backed provider work lands', () => {
+    for (const jurisdiction of australianJurisdictions.filter(
+      jurisdiction => jurisdiction !== 'au-commonwealth'
+    )) {
       const capability = getProviderCapability(jurisdiction);
 
       expect(capability.releaseChannel).toBe('planned');
@@ -106,16 +108,24 @@ describe('provider capability manifest', () => {
     const unsupported = getUnsupportedProviderCapability('au-commonwealth', 'search');
 
     expect(capability.sourceAuthority).toBe('Federal Register of Legislation public API');
-    expect(capability.releaseChannel).toBe('planned');
-    expect(unsupported).toMatchObject({
+    expect(capability.releaseChannel).toBe('prerelease');
+    expect(capability.features.search).toMatchObject({
+      status: 'supported',
+      sourceBacked: true,
+    });
+    expect(capability.features.export).toMatchObject({
+      status: 'supported',
+      sourceBacked: true,
+    });
+    expect(unsupported).toBeNull();
+    expect(getUnsupportedProviderCapability('au-commonwealth', 'citation')).toMatchObject({
       error: 'unsupported_provider_capability',
       jurisdiction: 'au-commonwealth',
       providerId: 'federal-register-of-legislation',
-      feature: 'search',
+      feature: 'citation',
       status: 'unsupported',
       sourceBacked: false,
     });
-    expect(unsupported?.message).toMatch(/Source validation is complete/);
   });
 
   it('records concrete source authorities for planned Australian providers', () => {

--- a/tests/provider-registry.test.ts
+++ b/tests/provider-registry.test.ts
@@ -7,7 +7,7 @@ import {
 } from '../src/providers/registry.ts';
 
 describe('provider registry', () => {
-  it('keeps New Zealand as the only runtime-supported provider', () => {
+  it('keeps New Zealand stable and Commonwealth prerelease as runtime-supported providers', () => {
     expect(getRuntimeProviderRegistry()).toEqual([
       expect.objectContaining({
         jurisdiction: 'nz',
@@ -15,27 +15,33 @@ describe('provider registry', () => {
         runtimeKind: 'legacy-nz-client',
         runtimeSupported: true,
       }),
+      expect.objectContaining({
+        jurisdiction: 'au-commonwealth',
+        providerId: 'federal-register-of-legislation',
+        runtimeKind: 'prerelease-au-adapter',
+        runtimeSupported: true,
+      }),
     ]);
   });
 
-  it('records the gated Commonwealth adapter without enabling runtime support', () => {
+  it('records the prerelease Commonwealth adapter with source-backed runtime support', () => {
     expect(getProviderRegistryEntry('au-commonwealth')).toMatchObject({
       jurisdiction: 'au-commonwealth',
       providerId: 'federal-register-of-legislation',
-      runtimeKind: 'gated-au-adapter',
-      runtimeSupported: false,
+      runtimeKind: 'prerelease-au-adapter',
+      runtimeSupported: true,
       source: {
         jurisdiction: 'au-commonwealth',
         providerId: 'federal-register-of-legislation',
         sourceAuthority: 'Federal Register of Legislation public API',
-        runtimeEnabled: false,
+        runtimeEnabled: true,
       },
       capability: {
-        releaseChannel: 'planned',
+        releaseChannel: 'prerelease',
         features: {
           search: {
-            status: 'unsupported',
-            sourceBacked: false,
+            status: 'supported',
+            sourceBacked: true,
           },
         },
       },

--- a/tests/provider-runtime.test.ts
+++ b/tests/provider-runtime.test.ts
@@ -12,18 +12,23 @@ describe('provider runtime gates', () => {
     expect(() => assertRuntimeProviderSupported('nz', 'export')).not.toThrow();
   });
 
-  it('blocks Commonwealth runtime use even with a gated adapter source card', () => {
-    const unsupported = getUnsupportedRuntimeProviderCapability('au-commonwealth', 'search');
+  it('allows Commonwealth prerelease runtime use for source-backed features', () => {
+    expect(getUnsupportedRuntimeProviderCapability('au-commonwealth', 'search')).toBeNull();
+    expect(getUnsupportedRuntimeProviderCapability('au-commonwealth', 'export')).toBeNull();
+    expect(() => assertRuntimeProviderSupported('au-commonwealth', 'getWork')).not.toThrow();
+  });
+
+  it('blocks incomplete Commonwealth runtime features', () => {
+    const unsupported = getUnsupportedRuntimeProviderCapability('au-commonwealth', 'citation');
 
     expect(unsupported).toMatchObject({
       error: 'unsupported_provider_capability',
       jurisdiction: 'au-commonwealth',
       providerId: 'federal-register-of-legislation',
-      feature: 'search',
+      feature: 'citation',
       status: 'unsupported',
       sourceBacked: false,
     });
-    expect(unsupported?.message).toMatch(/provider implementation is required/i);
   });
 
   it('blocks planned Australian providers before runtime clients are invoked', () => {

--- a/tests/provider-source-cards.test.ts
+++ b/tests/provider-source-cards.test.ts
@@ -42,16 +42,16 @@ describe('provider source cards', () => {
     }
   });
 
-  it('keeps the Commonwealth source metadata for preparation but gated from runtime release', () => {
+  it('keeps Commonwealth source metadata for prerelease runtime while blocking release', () => {
     const card = getProviderSourceCard('au-commonwealth');
 
     expect(card).toMatchObject({
       jurisdiction: 'au-commonwealth',
       providerId: 'federal-register-of-legislation',
       sourceAuthority: 'Federal Register of Legislation public API',
-      releaseChannel: 'planned',
-      runtimeSupported: false,
-      runtimeKind: 'gated-au-adapter',
+      releaseChannel: 'prerelease',
+      runtimeSupported: true,
+      runtimeKind: 'prerelease-au-adapter',
       releaseGate: {
         status: 'blocked',
       },
@@ -61,24 +61,34 @@ describe('provider source cards', () => {
       sourceMetadata: {
         apiBaseUrl: 'https://api.prod.legislation.gov.au/v1',
         registerBaseUrl: 'https://www.legislation.gov.au',
-        runtimeEnabled: false,
+        runtimeEnabled: true,
       },
     });
-    expect(card.sourceBackedFeatureSummary.sourceBacked).toEqual([]);
-    expect(card.sourceBackedFeatureSummary.notSourceBacked).toEqual([...runtimeFeatures]);
+    expect(card.sourceBackedFeatureSummary.sourceBacked).toEqual([
+      'search',
+      'getWork',
+      'getVersions',
+      'export',
+      'mcp',
+    ]);
+    expect(card.sourceBackedFeatureSummary.notSourceBacked).toEqual(['getVersion', 'citation']);
 
-    for (const feature of runtimeFeatures) {
+    for (const feature of ['search', 'getWork', 'getVersions', 'export', 'mcp'] as const) {
+      expect(card.sourceBackedFeatureSummary.features[feature]).toMatchObject({
+        status: 'supported',
+        sourceBacked: true,
+      });
+    }
+
+    for (const feature of ['getVersion', 'citation'] as const) {
       expect(card.sourceBackedFeatureSummary.features[feature]).toMatchObject({
         status: 'unsupported',
         sourceBacked: false,
       });
-      expect(card.sourceBackedFeatureSummary.features[feature].notes).toMatch(
-        /Source validation is complete/
-      );
     }
   });
 
-  it('blocks all Australian source cards until they are stable runtime-supported providers', () => {
+  it('blocks all Australian source cards from release until they are stable providers', () => {
     const australianCards = getProviderSourceCards().filter(card =>
       card.jurisdiction.startsWith('au-')
     );
@@ -86,12 +96,8 @@ describe('provider source cards', () => {
     expect(australianCards).toHaveLength(9);
 
     for (const card of australianCards) {
-      expect(card.runtimeSupported).toBe(false);
-      expect(card.releaseChannel).toBe('planned');
       expect(card.releaseGate.status).toBe('blocked');
       expect(card.submissionGate.status).toBe('blocked');
-      expect(card.sourceBackedFeatureSummary.sourceBacked).toEqual([]);
-      expect(card.sourceBackedFeatureSummary.notSourceBacked).toEqual([...runtimeFeatures]);
     }
   });
 


### PR DESCRIPTION
## Summary
- enable source-backed prerelease au-commonwealth runtime routing for search, get-work, versions, export, and MCP paths
- keep Commonwealth citation and single-version support blocked with structured unsupported capability errors
- add source-card provenance to export and MCP outputs and update Conductor tracks/gates to reflect prerelease-only status

## Validation
- corepack pnpm typecheck
- corepack pnpm test:run
- corepack pnpm build
- corepack pnpm gate:no-placeholder-legal-data
- corepack pnpm exec prettier --check <touched files>

## Notes
- NZ remains the only stable support lane.
- No publishing, deployment, registry submission, package rename, repo rename, or Rust migration is included.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Australian Commonwealth legislation is now available as prerelease support for search, work retrieval, versions, export, and MCP tools.
  * CLI commands (`search`, `get`) now support a `--jurisdiction` option to specify Commonwealth or New Zealand as the data source.
  * Export and MCP outputs include source attribution details identifying the provider and data source.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/edithatogo/nz-legislation/pull/25?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->