### PR TITLE
ci: run Conductor requirements gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -113,6 +113,31 @@ jobs:
       - name: Run typecheck
         run: pnpm typecheck
 
+  conductor-requirements:
+    name: Conductor Requirements Gate
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v5
+
+      - name: Enable pnpm via Corepack
+        run: |
+          corepack enable
+          corepack prepare pnpm@10.29.3 --activate
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: '20'
+          cache: 'pnpm'
+
+      - name: Install dependencies
+        run: pnpm install --no-frozen-lockfile
+
+      - name: Run Conductor requirements gate
+        run: pnpm gate:conductor-requirements
   test:
     name: Test (Node ${{ matrix.node-version }})
     runs-on: ubuntu-latest
@@ -149,7 +174,7 @@ jobs:
     name: Build
     runs-on: ubuntu-latest
     timeout-minutes: 15
-    needs: [format, lint, typecheck, test]
+    needs: [format, lint, typecheck, conductor-requirements, test]
 
     steps:
       - name: Check out repository


### PR DESCRIPTION
## Summary
- add a dedicated CI job for pnpm gate:conductor-requirements
- make the build job depend on the Conductor requirements gate so drift blocks the normal CI chain

## Validation
- corepack pnpm gate:conductor-requirements
- corepack pnpm exec prettier --check .github/workflows/ci.yml
- corepack pnpm typecheck