### PR TITLE
ci: add manifest docs drift gate

### DIFF
--- a/.changeset/manifest-docs-drift-gate.md
+++ b/.changeset/manifest-docs-drift-gate.md
@@ -1,0 +1,5 @@
+---
+'nz-legislation-tool': patch
+---
+
+Add a manifest/docs drift gate to keep public provider status claims aligned with the provider capability manifest.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -138,6 +138,31 @@ jobs:
 
       - name: Run Conductor requirements gate
         run: pnpm gate:conductor-requirements
+  manifest-docs:
+    name: Manifest Docs Drift Gate
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v5
+
+      - name: Enable pnpm via Corepack
+        run: |
+          corepack enable
+          corepack prepare pnpm@10.29.3 --activate
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: '20'
+          cache: 'pnpm'
+
+      - name: Install dependencies
+        run: pnpm install --no-frozen-lockfile
+
+      - name: Run manifest/docs drift gate
+        run: pnpm gate:manifest-docs
   test:
     name: Test (Node ${{ matrix.node-version }})
     runs-on: ubuntu-latest
@@ -174,7 +199,7 @@ jobs:
     name: Build
     runs-on: ubuntu-latest
     timeout-minutes: 15
-    needs: [format, lint, typecheck, conductor-requirements, test]
+    needs: [format, lint, typecheck, conductor-requirements, manifest-docs, test]
 
     steps:
       - name: Check out repository

--- a/docs/maintainers/australian-source-inventory.md
+++ b/docs/maintainers/australian-source-inventory.md
@@ -1,22 +1,22 @@
 # Australian Source Inventory
 
-This inventory records official source surfaces located for planned Australian
-providers. It is a roadmap control only. It does not mark any provider as
-runtime-supported, source-backed, or release-ready.
+This inventory records official source surfaces located for Australian providers.
+It is a roadmap control only. Runtime status must match the provider capability
+manifest and does not by itself authorize stable release claims.
 
 ## Inventory
 
-| Jurisdiction                 | Located official source                                                               | Current interpretation                                                                                                                                                                                    | Runtime status |
-| ---------------------------- | ------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------------- |
-| Australian Commonwealth      | Federal Register of Legislation public API, `https://api.prod.legislation.gov.au/v1/` | Source validation is recorded separately in `commonwealth-source-validation.md`. A mapping and injected client wrapper exist, but runtime routing is still disabled.                                      | Unsupported    |
-| Queensland                   | Queensland Legislation API service, `https://www.legislation.qld.gov.au/api`          | Source validation is recorded separately in `queensland-source-validation.md`. Official API exists, requires registration, documents a base URL, points to Swagger, and returns JSON, XML, HTML, and PDF. | Unsupported    |
-| New South Wales              | NSW legislation XML export, `https://legislation.nsw.gov.au/help/export`              | Source validation is recorded separately in `nsw-source-validation.md`. Official XML and bulk export routes exist for In force and Repealed collections, including JSON listing output for export URLs.   | Unsupported    |
-| Victoria                     | Victorian legislation website, `https://www.legislation.vic.gov.au/`                  | Source validation is recorded in `state-territory-source-validation.md`. Official primary source located; machine-readable discovery remains required.                                                    | Unsupported    |
-| South Australia              | South Australian Legislation website, `https://legislation.sa.gov.au/`                | Source validation is recorded in `state-territory-source-validation.md`. Official source located with browse, search, index, legislation lists, and a CC BY 4.0 site-content notice.                      | Unsupported    |
-| Western Australia            | Western Australian Legislation website, `https://www.legislation.wa.gov.au/`          | Source validation is recorded in `state-territory-source-validation.md`. Official source located with Acts, subsidiary legislation, legislation information, gazettes, search, and notification feeds.    | Unsupported    |
-| Tasmania                     | Tasmanian Legislation Online, `https://www.legislation.tas.gov.au/`                   | Source validation is recorded in `state-territory-source-validation.md`. Official source located with free public access, consolidated and as-made legislation, point-in-time coverage, and search.       | Unsupported    |
-| Australian Capital Territory | ACT Legislation Register, `https://www.legislation.act.gov.au/`                       | Source validation is recorded in `state-territory-source-validation.md`. Official authorised electronic statute book located; PDF authoritative status remains an adapter design constraint.              | Unsupported    |
-| Northern Territory           | Northern Territory legislation website, `https://legislation.nt.gov.au/`              | Source validation is recorded in `state-territory-source-validation.md`. Official source located with Bills, Acts, subordinate legislation, legislation information, gazettes, search, and archive paths. | Unsupported    |
+| Jurisdiction                 | Located official source                                                               | Current interpretation                                                                                                                                                                                                                              | Runtime status |
+| ---------------------------- | ------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------------- |
+| Australian Commonwealth      | Federal Register of Legislation public API, `https://api.prod.legislation.gov.au/v1/` | Source validation is recorded separately in `commonwealth-source-validation.md`. Runtime routing is enabled for source-backed prerelease search, get-work, versions, export, and MCP paths; citation and single-version support remain unsupported. | Prerelease     |
+| Queensland                   | Queensland Legislation API service, `https://www.legislation.qld.gov.au/api`          | Source validation is recorded separately in `queensland-source-validation.md`. Official API exists, requires registration, documents a base URL, points to Swagger, and returns JSON, XML, HTML, and PDF.                                           | Planned        |
+| New South Wales              | NSW legislation XML export, `https://legislation.nsw.gov.au/help/export`              | Source validation is recorded separately in `nsw-source-validation.md`. Official XML and bulk export routes exist for In force and Repealed collections, including JSON listing output for export URLs.                                             | Planned        |
+| Victoria                     | Victorian legislation website, `https://www.legislation.vic.gov.au/`                  | Source validation is recorded in `state-territory-source-validation.md`. Official primary source located; machine-readable discovery remains required.                                                                                              | Planned        |
+| South Australia              | South Australian Legislation website, `https://legislation.sa.gov.au/`                | Source validation is recorded in `state-territory-source-validation.md`. Official source located with browse, search, index, legislation lists, and a CC BY 4.0 site-content notice.                                                                | Planned        |
+| Western Australia            | Western Australian Legislation website, `https://www.legislation.wa.gov.au/`          | Source validation is recorded in `state-territory-source-validation.md`. Official source located with Acts, subsidiary legislation, legislation information, gazettes, search, and notification feeds.                                              | Planned        |
+| Tasmania                     | Tasmanian Legislation Online, `https://www.legislation.tas.gov.au/`                   | Source validation is recorded in `state-territory-source-validation.md`. Official source located with free public access, consolidated and as-made legislation, point-in-time coverage, and search.                                                 | Planned        |
+| Australian Capital Territory | ACT Legislation Register, `https://www.legislation.act.gov.au/`                       | Source validation is recorded in `state-territory-source-validation.md`. Official authorised electronic statute book located; PDF authoritative status remains an adapter design constraint.                                                        | Planned        |
+| Northern Territory           | Northern Territory legislation website, `https://legislation.nt.gov.au/`              | Source validation is recorded in `state-territory-source-validation.md`. Official source located with Bills, Acts, subordinate legislation, legislation information, gazettes, search, and archive paths.                                           | Planned        |
 
 ## Gates before provider implementation
 
@@ -26,8 +26,9 @@ runtime-supported, source-backed, or release-ready.
    and update cadence.
 3. Add provider-specific fixtures from real official-source responses or
    documents.
-4. Keep capability manifest entries unsupported until the provider maps search,
-   work, version, export, citation, and MCP behavior without placeholder legal
-   data.
+4. Keep capability manifest entries planned or unsupported until the provider
+   maps search, work, version, export, citation, and MCP behavior without
+   placeholder legal data. Commonwealth is the current prerelease exception for
+   source-backed search, get-work, versions, export, and MCP paths.
 5. Add source cards/provenance metadata before public docs, package metadata,
    website, MCP registry, IDE, or marketplace claims.

--- a/package.json
+++ b/package.json
@@ -35,7 +35,8 @@
     "audit:fix": "pnpm audit --fix",
     "docs": "typedoc",
     "docs:serve": "npx http-server docs/api -p 8080 -o",
-    "gate:conductor-requirements": "tsx scripts/check-conductor-requirements.ts"
+    "gate:conductor-requirements": "tsx scripts/check-conductor-requirements.ts",
+    "gate:manifest-docs": "tsx scripts/check-manifest-docs-drift.ts"
   },
   "keywords": [
     "nz",

--- a/scripts/check-manifest-docs-drift.ts
+++ b/scripts/check-manifest-docs-drift.ts
@@ -1,0 +1,137 @@
+import { readFileSync } from 'node:fs';
+
+import {
+  getProviderCapabilities,
+  type ProviderCapability,
+} from '../src/providers/capability-manifest.js';
+
+interface InventoryRow {
+  jurisdiction: string;
+  status: string;
+}
+
+const inventoryPath = 'docs/maintainers/australian-source-inventory.md';
+const llmsPath = 'llms.txt';
+const requirementsPath = 'conductor/requirements.md';
+
+const statusLabel = (capability: ProviderCapability): string => {
+  switch (capability.releaseChannel) {
+    case 'stable':
+      return 'Stable';
+    case 'prerelease':
+      return 'Prerelease';
+    case 'planned':
+      return 'Planned';
+  }
+};
+
+const read = (path: string): string => readFileSync(path, 'utf8');
+
+function parseInventoryRows(markdown: string): InventoryRow[] {
+  return markdown
+    .split(/\r?\n/)
+    .filter(line => line.startsWith('| ') && !line.includes('---'))
+    .map(line => line.split('|').map(cell => cell.trim()))
+    .filter(cells => cells.length >= 6 && cells[1] !== 'Jurisdiction')
+    .map(cells => ({ jurisdiction: cells[1], status: cells[4] }));
+}
+
+const failures: string[] = [];
+const capabilities = getProviderCapabilities();
+const australianCapabilities = capabilities.filter(capability =>
+  capability.jurisdiction.startsWith('au-')
+);
+const inventory = read(inventoryPath);
+const inventoryRows = parseInventoryRows(inventory);
+
+for (const capability of australianCapabilities) {
+  const row = inventoryRows.find(item => item.jurisdiction === capability.label);
+  const expectedStatus = statusLabel(capability);
+
+  if (!row) {
+    failures.push(`${inventoryPath} is missing a row for ${capability.label}.`);
+    continue;
+  }
+
+  if (row.status !== expectedStatus) {
+    failures.push(
+      `${inventoryPath} lists ${capability.label} as ${row.status}; expected ${expectedStatus} from provider capability manifest.`
+    );
+  }
+}
+
+const llms = read(llmsPath);
+if (!llms.includes('Australian support is prerelease.')) {
+  failures.push(`${llmsPath} must describe Australian support as prerelease.`);
+}
+
+if (!llms.includes('runtime capability manifest')) {
+  failures.push(`${llmsPath} must direct readers to the runtime capability manifest.`);
+}
+
+const requirements = read(requirementsPath);
+for (const capability of capabilities) {
+  const expectedStatus = statusLabel(capability).toLowerCase();
+  if (capability.jurisdiction === 'nz') {
+    if (!requirements.includes('Present stable compatibility provider')) {
+      failures.push(
+        `${requirementsPath} must record NZ as the present stable compatibility provider.`
+      );
+    }
+    continue;
+  }
+
+  if (!requirements.includes(capability.label)) {
+    failures.push(`${requirementsPath} is missing provider label ${capability.label}.`);
+  }
+
+  if (!requirements.toLowerCase().includes(expectedStatus)) {
+    failures.push(
+      `${requirementsPath} does not include the manifest release channel ${expectedStatus} for ${capability.label}.`
+    );
+  }
+}
+
+const forbiddenClaimPatterns = [
+  /Australian support is stable/i,
+  /stable Australian support/i,
+  /all Australian jurisdictions (are )?supported/i,
+  /Queensland .*runtime-supported/i,
+  /New South Wales .*runtime-supported/i,
+  /Victoria .*runtime-supported/i,
+  /South Australia .*runtime-supported/i,
+  /Western Australia .*runtime-supported/i,
+  /Tasmania .*runtime-supported/i,
+  /Australian Capital Territory .*runtime-supported/i,
+  /Northern Territory .*runtime-supported/i,
+];
+
+const claimSurfaces = [
+  'README.md',
+  'llms.txt',
+  'docs/maintainers/australian-source-inventory.md',
+  'docs/maintainers/distribution-submission-map.md',
+  'integrations/mcp/registry-submission-checklist.md',
+  'integrations/README.md',
+];
+
+for (const path of claimSurfaces) {
+  const content = read(path);
+  for (const pattern of forbiddenClaimPatterns) {
+    if (pattern.test(content)) {
+      failures.push(`${path} contains forbidden provider capability claim matching ${pattern}.`);
+    }
+  }
+}
+
+if (failures.length > 0) {
+  console.error('Manifest/docs drift gate failed:');
+  for (const failure of failures) {
+    console.error(`- ${failure}`);
+  }
+  process.exit(1);
+}
+
+console.log(
+  `Manifest/docs drift gate passed: ${australianCapabilities.length} Australian provider inventory rows match the capability manifest.`
+);


### PR DESCRIPTION
## Summary
- add pnpm gate:manifest-docs to compare provider capability manifest status against maintainer docs and high-level claim surfaces
- update the Australian source inventory so Commonwealth is recorded as prerelease and remaining AU providers as planned
- add the new gate to CI and make build depend on it

## Validation
- corepack pnpm gate:manifest-docs
- corepack pnpm gate:conductor-requirements
- corepack pnpm exec prettier --check .github/workflows/ci.yml .changeset/manifest-docs-drift-gate.md docs/maintainers/australian-source-inventory.md package.json scripts/check-manifest-docs-drift.ts
- corepack pnpm typecheck
- corepack pnpm build
- corepack pnpm test:run