### PR TITLE
ci: add install snippet gate

### DIFF
--- a/.changeset/install-snippet-gate.md
+++ b/.changeset/install-snippet-gate.md
@@ -1,0 +1,5 @@
+---
+'nz-legislation-tool': patch
+---
+
+Add an install snippet gate to keep documented CLI and MCP setup commands aligned with packaged binary names.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -163,6 +163,31 @@ jobs:
 
       - name: Run manifest/docs drift gate
         run: pnpm gate:manifest-docs
+  install-snippets:
+    name: Install Snippet Gate
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v5
+
+      - name: Enable pnpm via Corepack
+        run: |
+          corepack enable
+          corepack prepare pnpm@10.29.3 --activate
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: '20'
+          cache: 'pnpm'
+
+      - name: Install dependencies
+        run: pnpm install --no-frozen-lockfile
+
+      - name: Run install snippet gate
+        run: pnpm gate:install-snippets
   test:
     name: Test (Node ${{ matrix.node-version }})
     runs-on: ubuntu-latest
@@ -199,7 +224,7 @@ jobs:
     name: Build
     runs-on: ubuntu-latest
     timeout-minutes: 15
-    needs: [format, lint, typecheck, conductor-requirements, manifest-docs, test]
+    needs: [format, lint, typecheck, conductor-requirements, manifest-docs, install-snippets, test]
 
     steps:
       - name: Check out repository

--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ Example MCP command configuration:
 **Option A: Try without installing (recommended for first time)**
 
 ```bash
-npx nz-legislation-tool search --query "health"
+npx -y --package nz-legislation-tool nzlegislation search --query "health"
 ```
 
 **Option B: Install globally (recommended for regular use)**
@@ -500,7 +500,7 @@ npm install -g nz-legislation-tool
 ### Option 2: npx (Try before installing)
 
 ```bash
-npx nz-legislation-tool search --query "health"
+npx -y --package nz-legislation-tool nzlegislation search --query "health"
 ```
 
 **Pros:** No installation, try before committing  

--- a/docs/maintainers/install-snippet-verification.md
+++ b/docs/maintainers/install-snippet-verification.md
@@ -29,9 +29,9 @@ For each applicable surface, verify the published snippet from a clean shell or
 fresh host profile:
 
 - [ ] `npm install -g nz-legislation-tool`
-- [ ] `npx -y nz-legislation-tool --help`
+- [ ] `npx -y --package nz-legislation-tool nzlegislation --help`
 - [ ] local package install from the built tarball or workspace package
-- [ ] MCP stdio command and JSON config
+- [ ] `npx -y --package nz-legislation-tool nzlegislation-mcp`\n- [ ] MCP stdio command and JSON config
 - [ ] Claude Desktop MCP config
 - [ ] Claude Code / project instruction snippet
 - [ ] Codex `AGENTS.md` / MCP config snippet

--- a/integrations/mcp/example-configs.md
+++ b/integrations/mcp/example-configs.md
@@ -7,7 +7,7 @@
   "mcpServers": {
     "anz-legislation": {
       "command": "npx",
-      "args": ["-y", "nz-legislation-tool", "mcp"],
+      "args": ["-y", "--package", "nz-legislation-tool", "nzlegislation-mcp"],
       "env": {
         "NZ_LEGISLATION_API_KEY": "..."
       }
@@ -16,7 +16,7 @@
 }
 ```
 
-Update this once the actual packaged MCP command is verified. Before publishing
+This uses the packaged `nzlegislation-mcp` binary. Before publishing
 or submitting any MCP snippet, record the check in
 `docs/maintainers/install-snippet-verification.md` and keep NZ stable support
 separate from any AU planned or unsupported claims.

--- a/package.json
+++ b/package.json
@@ -36,7 +36,8 @@
     "docs": "typedoc",
     "docs:serve": "npx http-server docs/api -p 8080 -o",
     "gate:conductor-requirements": "tsx scripts/check-conductor-requirements.ts",
-    "gate:manifest-docs": "tsx scripts/check-manifest-docs-drift.ts"
+    "gate:manifest-docs": "tsx scripts/check-manifest-docs-drift.ts",
+    "gate:install-snippets": "tsx scripts/check-install-snippets.ts"
   },
   "keywords": [
     "nz",

--- a/scripts/check-install-snippets.ts
+++ b/scripts/check-install-snippets.ts
@@ -1,0 +1,101 @@
+import { readFileSync } from 'node:fs';
+
+interface PackageJson {
+  bin?: Record<string, string>;
+  scripts?: Record<string, string>;
+}
+
+const read = (path: string): string => readFileSync(path, 'utf8');
+const packageJson = JSON.parse(read('package.json')) as PackageJson;
+const bins = packageJson.bin ?? {};
+const failures: string[] = [];
+
+const requiredBins = ['nzlegislation', 'nzlegislation-mcp'];
+for (const bin of requiredBins) {
+  if (!bins[bin]) {
+    failures.push(`package.json is missing required bin ${bin}.`);
+  }
+}
+
+const snippetExpectations: Array<{ path: string; required: string[] }> = [
+  {
+    path: 'README.md',
+    required: [
+      'npm install -g nz-legislation-tool',
+      'nzlegislation search --query "health act"',
+      'nzlegislation-mcp',
+      'npx -y --package nz-legislation-tool nzlegislation search --query "health"',
+    ],
+  },
+  {
+    path: 'integrations/mcp/example-configs.md',
+    required: [
+      '"command": "npx"',
+      '"args": ["-y", "--package", "nz-legislation-tool", "nzlegislation-mcp"]',
+      'NZ_LEGISLATION_API_KEY',
+    ],
+  },
+  {
+    path: 'docs/maintainers/install-snippet-verification.md',
+    required: [
+      '`npm install -g nz-legislation-tool`',
+      '`npx -y --package nz-legislation-tool nzlegislation --help`',
+      '`npx -y --package nz-legislation-tool nzlegislation-mcp`',
+    ],
+  },
+];
+
+for (const expectation of snippetExpectations) {
+  const content = read(expectation.path);
+  for (const required of expectation.required) {
+    if (!content.includes(required)) {
+      failures.push(`${expectation.path} is missing required install snippet: ${required}`);
+    }
+  }
+}
+
+const forbiddenPatterns: Array<{ pattern: RegExp; reason: string }> = [
+  {
+    pattern: /npx\s+(?!-y\s+--package\s+nz-legislation-tool\s+nzlegislation)nz-legislation-tool\b/g,
+    reason:
+      'use `npx -y --package nz-legislation-tool nzlegislation ...` because the package bin is `nzlegislation`.',
+  },
+  {
+    pattern: /"args"\s*:\s*\[\s*"-y"\s*,\s*"nz-legislation-tool"\s*,\s*"mcp"\s*\]/g,
+    reason: 'MCP snippets must execute the packaged `nzlegislation-mcp` binary.',
+  },
+  {
+    pattern: /\bnz-legislation-tool\s+mcp\b/g,
+    reason: 'there is no documented `mcp` subcommand; use `nzlegislation-mcp`.',
+  },
+];
+
+const checkedSnippetFiles = [
+  'README.md',
+  'integrations/mcp/example-configs.md',
+  'docs/maintainers/install-snippet-verification.md',
+  'integrations/mcp/registry-submission-checklist.md',
+  'integrations/mcp/submission-evidence-template.md',
+];
+
+for (const path of checkedSnippetFiles) {
+  const content = read(path);
+  for (const { pattern, reason } of forbiddenPatterns) {
+    const matches = [...content.matchAll(pattern)];
+    if (matches.length > 0) {
+      failures.push(
+        `${path} contains ${matches.length} unverified install snippet pattern(s): ${reason}`
+      );
+    }
+  }
+}
+
+if (failures.length > 0) {
+  console.error('Install snippet gate failed:');
+  for (const failure of failures) {
+    console.error(`- ${failure}`);
+  }
+  process.exit(1);
+}
+
+console.log('Install snippet gate passed: package bins and high-risk snippets are aligned.');


### PR DESCRIPTION
## Summary
- add pnpm gate:install-snippets to keep documented CLI and MCP snippets aligned with package bin names
- correct high-risk README and MCP snippets to use 
px -y --package nz-legislation-tool nzlegislation ... and 
zlegislation-mcp
- add the install snippet gate to CI and make build depend on it

## Validation
- corepack pnpm gate:install-snippets
- corepack pnpm gate:manifest-docs
- corepack pnpm gate:conductor-requirements
- corepack pnpm exec prettier --check .github/workflows/ci.yml .changeset/install-snippet-gate.md README.md docs/maintainers/install-snippet-verification.md integrations/mcp/example-configs.md package.json scripts/check-install-snippets.ts
- corepack pnpm typecheck
- corepack pnpm build
- corepack pnpm test:run