### PR TITLE
ci: add security provenance gate

### DIFF
--- a/.changeset/security-provenance-gate.md
+++ b/.changeset/security-provenance-gate.md
@@ -1,0 +1,5 @@
+---
+'nz-legislation-tool': patch
+---
+
+Add a security/provenance gate for release workflows and external submission evidence.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -188,6 +188,31 @@ jobs:
 
       - name: Run install snippet gate
         run: pnpm gate:install-snippets
+  security-provenance:
+    name: Security Provenance Gate
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v5
+
+      - name: Enable pnpm via Corepack
+        run: |
+          corepack enable
+          corepack prepare pnpm@10.29.3 --activate
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: '20'
+          cache: 'pnpm'
+
+      - name: Install dependencies
+        run: pnpm install --no-frozen-lockfile
+
+      - name: Run security/provenance gate
+        run: pnpm gate:security-provenance
   test:
     name: Test (Node ${{ matrix.node-version }})
     runs-on: ubuntu-latest
@@ -224,7 +249,17 @@ jobs:
     name: Build
     runs-on: ubuntu-latest
     timeout-minutes: 15
-    needs: [format, lint, typecheck, conductor-requirements, manifest-docs, install-snippets, test]
+    needs:
+      [
+        format,
+        lint,
+        typecheck,
+        conductor-requirements,
+        manifest-docs,
+        install-snippets,
+        security-provenance,
+        test,
+      ]
 
     steps:
       - name: Check out repository

--- a/.github/workflows/publish-github-packages.yml
+++ b/.github/workflows/publish-github-packages.yml
@@ -40,6 +40,13 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
+      - name: Run mirror gate checks
+        run: |
+          pnpm gate:no-placeholder-legal-data
+          pnpm gate:conductor-requirements
+          pnpm gate:manifest-docs
+          pnpm gate:install-snippets
+          pnpm gate:security-provenance
       - name: Build package
         run: pnpm run build
 

--- a/.github/workflows/release-next.yml
+++ b/.github/workflows/release-next.yml
@@ -57,6 +57,11 @@ jobs:
 
       - name: Run prerelease gate checks
         run: |
+          pnpm gate:no-placeholder-legal-data
+          pnpm gate:conductor-requirements
+          pnpm gate:manifest-docs
+          pnpm gate:install-snippets
+          pnpm gate:security-provenance
           pnpm typecheck
           pnpm test:run
           pnpm build

--- a/.github/workflows/release-stable.yml
+++ b/.github/workflows/release-stable.yml
@@ -58,6 +58,11 @@ jobs:
 
       - name: Run release gate checks
         run: |
+          pnpm gate:no-placeholder-legal-data
+          pnpm gate:conductor-requirements
+          pnpm gate:manifest-docs
+          pnpm gate:install-snippets
+          pnpm gate:security-provenance
           pnpm typecheck
           pnpm test:run
           pnpm build

--- a/docs/maintainers/security-provenance-review.md
+++ b/docs/maintainers/security-provenance-review.md
@@ -1,0 +1,66 @@
+# Security and Provenance Review
+
+This review is a blocking release/submission gate for package publishing,
+website deployment, registry submission, marketplace listing, Docker/GHCR,
+Homebrew, assistant integration, IDE extension, and any other external
+publication surface.
+
+## Current verdict
+
+Status: blocked for external submission and publication until a release owner
+records target-specific evidence for the channel being released.
+
+The repository may prepare tracks, docs, manifests, and local validation gates,
+but this document does not authorize publication, deployment, marketplace
+submission, registry submission, package renaming, repository renaming, or a Rust
+rewrite.
+
+## Required evidence
+
+For each release or submission channel, record:
+
+| Evidence area           | Required evidence                                                                                                                                                                          |
+| ----------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| Package provenance      | npm trusted publishing or `npm publish --provenance`, GitHub Packages provenance notes, package name, version, registry, and tag.                                                          |
+| Workflow permissions    | GitHub Actions permissions are least-privilege for the channel and reviewed before publish.                                                                                                |
+| Release automation      | Release workflows run typecheck, tests, build, no-placeholder legal data, Conductor requirements, manifest/docs drift, install snippets, and this security/provenance gate before publish. |
+| Dependency posture      | `pnpm audit` or GitHub dependency review result is recorded, with accepted residual risk documented.                                                                                       |
+| Secret handling         | API keys, npm tokens, GitHub tokens, MCP host secrets, and assistant/IDE credentials are not committed and are stored through host-appropriate secret storage.                             |
+| Generated artifacts     | Generated files, bundled outputs, packages, archives, images, formulae, and listing metadata are reproducible or reviewed before release.                                                  |
+| Listing claims          | README, docs, package metadata, registry copy, marketplace text, and release notes match the provider capability manifest.                                                                 |
+| Legal-data truthfulness | No placeholder legal data is exposed as real support; unsupported providers return structured unsupported capability errors.                                                               |
+| Prompt/tool safety      | MCP and assistant integration docs describe provider limits, avoid shell/file-system expansion claims, and do not expose community plugin loading without a trust model.                   |
+
+## Channel review checklist
+
+- [ ] npm stable package
+- [ ] npm prerelease package
+- [ ] GitHub Packages mirror
+- [ ] GitHub Releases
+- [ ] website/docs deployment
+- [ ] MCP generic host docs
+- [ ] Smithery and other MCP directories
+- [ ] Claude integration
+- [ ] Codex integration
+- [ ] GitHub Copilot integration
+- [ ] Gemini integration
+- [ ] Qwen integration
+- [ ] VS Code Marketplace
+- [ ] Open VSX
+- [ ] JetBrains Marketplace
+- [ ] Docker/GHCR
+- [ ] Homebrew
+
+Mark channels not included in the release as not applicable in the release PR.
+
+## Security posture notes
+
+- Stable support remains New Zealand only unless a provider-specific promotion
+  passes all gates.
+- Australian Commonwealth support is prerelease and source-backed only for the
+  capabilities listed in the provider capability manifest.
+- Remaining Australian providers are planned until source validation, runtime,
+  provenance, docs, install, and release gates pass.
+- Public listing copy must not claim unsupported Australian coverage.
+- External submissions must be rechecked against the current target-specific
+  submission rules immediately before submission.

--- a/package.json
+++ b/package.json
@@ -37,7 +37,8 @@
     "docs:serve": "npx http-server docs/api -p 8080 -o",
     "gate:conductor-requirements": "tsx scripts/check-conductor-requirements.ts",
     "gate:manifest-docs": "tsx scripts/check-manifest-docs-drift.ts",
-    "gate:install-snippets": "tsx scripts/check-install-snippets.ts"
+    "gate:install-snippets": "tsx scripts/check-install-snippets.ts",
+    "gate:security-provenance": "tsx scripts/check-security-provenance.ts"
   },
   "keywords": [
     "nz",

--- a/scripts/check-security-provenance.ts
+++ b/scripts/check-security-provenance.ts
@@ -1,0 +1,138 @@
+import { readFileSync } from 'node:fs';
+
+const read = (path: string): string => readFileSync(path, 'utf8');
+const failures: string[] = [];
+
+function requireIncludes(path: string, needles: string[]): void {
+  const content = read(path);
+  for (const needle of needles) {
+    if (!content.includes(needle)) {
+      failures.push(`${path} is missing required text: ${needle}`);
+    }
+  }
+}
+
+const requiredDocs = [
+  'SECURITY.md',
+  'docs/maintainers/security-and-submission-gates-v9.md',
+  'docs/maintainers/security-provenance-review.md',
+  'conductor/tracks/anz-platform-release-and-distribution/release-submission-gates.md',
+  'integrations/mcp/registry-submission-checklist.md',
+];
+
+for (const path of requiredDocs) {
+  try {
+    read(path);
+  } catch {
+    failures.push(`Missing security/provenance document: ${path}`);
+  }
+}
+
+requireIncludes('SECURITY.md', [
+  'Reporting a Vulnerability',
+  'Please do NOT report security vulnerabilities through public GitHub issues.',
+  'Secure API key handling',
+]);
+
+requireIncludes('docs/maintainers/security-and-submission-gates-v9.md', [
+  'Gate A',
+  'Gate B',
+  'Gate C',
+  'Gate D',
+  'Gate E',
+  'package provenance',
+  'MCP safety',
+  'listing truthfulness',
+]);
+
+requireIncludes('docs/maintainers/security-provenance-review.md', [
+  'Status: blocked for external submission and publication',
+  'Package provenance',
+  'Workflow permissions',
+  'Release automation',
+  'Dependency posture',
+  'Secret handling',
+  'Generated artifacts',
+  'Listing claims',
+  'Legal-data truthfulness',
+]);
+
+requireIncludes(
+  'conductor/tracks/anz-platform-release-and-distribution/release-submission-gates.md',
+  ['Security/provenance review', 'BLOCKING', 'Gate evidence must be committed in this repository']
+);
+
+const releaseGateCommands = [
+  'pnpm gate:no-placeholder-legal-data',
+  'pnpm gate:conductor-requirements',
+  'pnpm gate:manifest-docs',
+  'pnpm gate:install-snippets',
+  'pnpm gate:security-provenance',
+  'pnpm typecheck',
+  'pnpm test:run',
+  'pnpm build',
+];
+
+for (const workflow of [
+  '.github/workflows/release-stable.yml',
+  '.github/workflows/release-next.yml',
+]) {
+  requireIncludes(workflow, [
+    'id-token: write',
+    'npm publish --provenance',
+    'ENABLE_AUTOMATED_NPM_PUBLISH',
+  ]);
+  requireIncludes(workflow, releaseGateCommands);
+}
+
+requireIncludes('.github/workflows/publish-github-packages.yml', [
+  'packages: write',
+  'pnpm gate:security-provenance',
+  'pnpm gate:install-snippets',
+  'pnpm gate:manifest-docs',
+  'pnpm run build',
+]);
+
+requireIncludes('.github/workflows/ci.yml', [
+  'Security Provenance Gate',
+  'pnpm gate:security-provenance',
+  'security-provenance',
+]);
+
+const packageJson = JSON.parse(read('package.json')) as { scripts?: Record<string, string> };
+if (
+  packageJson.scripts?.['gate:security-provenance'] !== 'tsx scripts/check-security-provenance.ts'
+) {
+  failures.push(
+    'package.json must define gate:security-provenance as tsx scripts/check-security-provenance.ts'
+  );
+}
+
+const forbiddenPublicationClaims = [
+  /external publication is approved/i,
+  /registry submission is approved/i,
+  /marketplace submission is approved/i,
+  /security gate passed for release/i,
+];
+
+for (const path of [
+  'docs/maintainers/security-provenance-review.md',
+  'docs/maintainers/security-and-submission-gates-v9.md',
+]) {
+  const content = read(path);
+  for (const pattern of forbiddenPublicationClaims) {
+    if (pattern.test(content)) {
+      failures.push(`${path} contains a premature approval claim matching ${pattern}.`);
+    }
+  }
+}
+
+if (failures.length > 0) {
+  console.error('Security/provenance gate failed:');
+  for (const failure of failures) {
+    console.error(`- ${failure}`);
+  }
+  process.exit(1);
+}
+
+console.log('Security/provenance gate passed: release workflows and review artifacts are guarded.');


### PR DESCRIPTION
## Summary
- add a Security Provenance Gate CI job and package script
- require security/provenance checks in stable, next, and GitHub Packages release workflows
- document current security/provenance review status as blocked for external publication until gates pass

## Validation
- corepack pnpm gate:security-provenance
- corepack pnpm gate:no-placeholder-legal-data
- corepack pnpm gate:install-snippets
- corepack pnpm gate:manifest-docs
- corepack pnpm gate:conductor-requirements
- corepack pnpm typecheck
- corepack pnpm test:run
- corepack pnpm build
- corepack pnpm exec prettier --check .changeset/security-provenance-gate.md .github/workflows/ci.yml .github/workflows/release-stable.yml .github/workflows/release-next.yml .github/workflows/publish-github-packages.yml docs/maintainers/security-provenance-review.md package.json scripts/check-security-provenance.ts