### PR TITLE
ci: add release notes gate

### DIFF
--- a/.changeset/release-notes-gate.md
+++ b/.changeset/release-notes-gate.md
@@ -1,0 +1,5 @@
+---
+'nz-legislation-tool': patch
+---
+
+Add a release notes gate to keep NZ stable support distinct from Australian prerelease or planned support before publication.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -213,6 +213,31 @@ jobs:
 
       - name: Run security/provenance gate
         run: pnpm gate:security-provenance
+  release-notes:
+    name: Release Notes Gate
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v5
+
+      - name: Enable pnpm via Corepack
+        run: |
+          corepack enable
+          corepack prepare pnpm@10.29.3 --activate
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: '20'
+          cache: 'pnpm'
+
+      - name: Install dependencies
+        run: pnpm install --no-frozen-lockfile
+
+      - name: Run release notes gate
+        run: pnpm gate:release-notes
   test:
     name: Test (Node ${{ matrix.node-version }})
     runs-on: ubuntu-latest
@@ -258,6 +283,7 @@ jobs:
         manifest-docs,
         install-snippets,
         security-provenance,
+        release-notes,
         test,
       ]
 

--- a/.github/workflows/publish-github-packages.yml
+++ b/.github/workflows/publish-github-packages.yml
@@ -47,6 +47,7 @@ jobs:
           pnpm gate:manifest-docs
           pnpm gate:install-snippets
           pnpm gate:security-provenance
+          pnpm gate:release-notes
       - name: Build package
         run: pnpm run build
 

--- a/.github/workflows/release-next.yml
+++ b/.github/workflows/release-next.yml
@@ -62,6 +62,7 @@ jobs:
           pnpm gate:manifest-docs
           pnpm gate:install-snippets
           pnpm gate:security-provenance
+          pnpm gate:release-notes
           pnpm typecheck
           pnpm test:run
           pnpm build

--- a/.github/workflows/release-stable.yml
+++ b/.github/workflows/release-stable.yml
@@ -63,6 +63,7 @@ jobs:
           pnpm gate:manifest-docs
           pnpm gate:install-snippets
           pnpm gate:security-provenance
+          pnpm gate:release-notes
           pnpm typecheck
           pnpm test:run
           pnpm build

--- a/conductor/tracks/anz-platform-release-and-distribution/plan.md
+++ b/conductor/tracks/anz-platform-release-and-distribution/plan.md
@@ -44,7 +44,8 @@
 - Confirm package metadata for stable NZ support and Australian prerelease
   language.
 - Keep legacy package and binary compatibility.
-- Confirm release notes distinguish NZ stable from Australian prerelease support.
+- [x] Add an executable release notes gate that distinguishes NZ stable from
+      Australian prerelease support.
 
 ## Phase 3: Provider truthfulness
 
@@ -138,8 +139,8 @@ wired while install-snippet verification remains.
 - Define Homebrew formula expectations before any tap or formula is published.
 - Maintain a registry/listing tracker with review dates and renewal dates.
 - Monitor upstream source drift and legal-data provider status.
-- Keep all release automation guarded by provenance, docs, install, and release
-  note checks.
+- [x] Keep all release automation guarded by provenance, docs, install, and
+      release note checks.
 
 ## Phase 11: Long-term Rust migration readiness
 

--- a/conductor/tracks/anz-publication-package-registries/plan.md
+++ b/conductor/tracks/anz-publication-package-registries/plan.md
@@ -6,7 +6,8 @@
 
 - [x] Add package registry contracts to `conductor/requirements.md`.
 - [x] Add this Conductor track.
-- [ ] Add metadata/release-note drift checks against the capability manifest.
+- [x] Add release-note checks that reject premature Australian stable-support
+      claims and require prerelease/planned language for AU-scoped changesets.
 
 ## Phase 2: Publication readiness
 
@@ -14,5 +15,5 @@
 
 - [ ] Verify npm stable and prerelease metadata.
 - [ ] Verify GitHub Packages provenance expectations.
-- [ ] Verify GitHub Release note template distinguishes NZ stable from AU
+- [x] Verify GitHub Release note template distinguishes NZ stable from AU
       prerelease support.

--- a/package.json
+++ b/package.json
@@ -38,7 +38,8 @@
     "gate:conductor-requirements": "tsx scripts/check-conductor-requirements.ts",
     "gate:manifest-docs": "tsx scripts/check-manifest-docs-drift.ts",
     "gate:install-snippets": "tsx scripts/check-install-snippets.ts",
-    "gate:security-provenance": "tsx scripts/check-security-provenance.ts"
+    "gate:security-provenance": "tsx scripts/check-security-provenance.ts",
+    "gate:release-notes": "tsx scripts/check-release-notes.ts"
   },
   "keywords": [
     "nz",

--- a/scripts/check-release-notes.ts
+++ b/scripts/check-release-notes.ts
@@ -1,0 +1,146 @@
+import { existsSync, readFileSync, readdirSync } from 'node:fs';
+import { join } from 'node:path';
+
+const read = (path: string): string => readFileSync(path, 'utf8');
+const failures: string[] = [];
+const normalize = (value: string): string => value.replace(/\s+/g, ' ').trim();
+
+function requireIncludes(path: string, needles: string[]): void {
+  const content = normalize(read(path));
+  for (const needle of needles) {
+    if (!content.includes(normalize(needle))) {
+      failures.push(`${path} is missing required text: ${needle}`);
+    }
+  }
+}
+
+function rejectPatterns(path: string, patterns: Array<{ pattern: RegExp; reason: string }>): void {
+  const content = read(path);
+  for (const { pattern, reason } of patterns) {
+    if (pattern.test(content)) {
+      failures.push(`${path} contains forbidden release-note language: ${reason}`);
+    }
+  }
+}
+
+const releaseNoteDocs = [
+  'docs/maintainers/release-notes-anz-readiness-draft.md',
+  'conductor/tracks/anz-platform-release-and-distribution/release-submission-gates.md',
+  'conductor/tracks/anz-platform-release-and-distribution/plan.md',
+  'conductor/tracks/anz-publication-package-registries/plan.md',
+];
+
+for (const path of releaseNoteDocs) {
+  if (!existsSync(path)) {
+    failures.push(`Missing release-note gate document: ${path}`);
+  }
+}
+
+requireIncludes('docs/maintainers/release-notes-anz-readiness-draft.md', [
+  'stable New Zealand legislation support',
+  'New Zealand support remains the stable, supported runtime surface',
+  'Australian support is prerelease/planned only',
+  'No packages are published by this PR',
+  'Future external release notes must keep the distinction between stable New Zealand support and Australian prerelease/planned support',
+]);
+
+requireIncludes(
+  'conductor/tracks/anz-platform-release-and-distribution/release-submission-gates.md',
+  [
+    'NZ stable/Australian prerelease release notes',
+    'Release notes clearly distinguish NZ stable support from Australian prerelease or planned support.',
+    'between stable New Zealand support and Australian prerelease or planned',
+  ]
+);
+
+requireIncludes('conductor/tracks/anz-platform-release-and-distribution/plan.md', [
+  'Add an executable release notes gate that distinguishes NZ stable from Australian prerelease support.',
+  'Keep all release automation guarded by provenance, docs, install, and release note checks.',
+]);
+
+requireIncludes('conductor/tracks/anz-publication-package-registries/plan.md', [
+  'Verify GitHub Release note template distinguishes NZ stable from AU',
+  'prerelease support.',
+]);
+
+const workflowGateCommand = 'pnpm gate:release-notes';
+for (const workflow of [
+  '.github/workflows/ci.yml',
+  '.github/workflows/release-stable.yml',
+  '.github/workflows/release-next.yml',
+  '.github/workflows/publish-github-packages.yml',
+]) {
+  requireIncludes(workflow, [workflowGateCommand]);
+}
+
+const packageJson = JSON.parse(read('package.json')) as { scripts?: Record<string, string> };
+if (packageJson.scripts?.['gate:release-notes'] !== 'tsx scripts/check-release-notes.ts') {
+  failures.push(
+    'package.json must define gate:release-notes as tsx scripts/check-release-notes.ts'
+  );
+}
+
+const prematureStableClaims = [
+  {
+    pattern: /\bAustralian\s+(?:runtime\s+)?support\s+(?:is\s+)?stable\b/i,
+    reason: 'Australian support must not be described as stable.',
+  },
+  {
+    pattern: /\bstable\s+Australian\s+(?:runtime\s+)?support\b/i,
+    reason: 'Australian support must remain prerelease/planned until release gates pass.',
+  },
+  {
+    pattern: /\bAU\s+(?:runtime\s+)?support\s+(?:is\s+)?stable\b/i,
+    reason: 'AU support must not be described as stable.',
+  },
+  {
+    pattern: /\bproduction-ready\s+Australian\s+(?:runtime\s+)?support\b/i,
+    reason: 'Australian runtime support is not production-ready.',
+  },
+];
+
+for (const path of releaseNoteDocs) {
+  if (existsSync(path)) {
+    rejectPatterns(path, prematureStableClaims);
+  }
+}
+
+const australianScopePattern =
+  /\b(Australia|Australian|ANZ|Commonwealth|Queensland|NSW|Victoria|Tasmania|ACT|Northern Territory|South Australia|Western Australia)\b/i;
+const constrainedStatusPattern =
+  /\b(prerelease|planned|unsupported|gated|blocked|readiness|not wired|without enabling|source-validation|required)\b/i;
+
+const changesetDir = '.changeset';
+if (existsSync(changesetDir)) {
+  for (const entry of readdirSync(changesetDir)) {
+    if (!entry.endsWith('.md') || entry === 'README.md') {
+      continue;
+    }
+
+    const path = join(changesetDir, entry).replaceAll('\\', '/');
+    const content = read(path);
+    if (!australianScopePattern.test(content)) {
+      continue;
+    }
+
+    if (!constrainedStatusPattern.test(content)) {
+      failures.push(
+        `${path} mentions Australian/ANZ scope but does not state prerelease, planned, unsupported, gated, blocked, readiness, or source-validation status.`
+      );
+    }
+
+    rejectPatterns(path, prematureStableClaims);
+  }
+}
+
+if (failures.length > 0) {
+  console.error('Release notes gate failed:');
+  for (const failure of failures) {
+    console.error(`- ${failure}`);
+  }
+  process.exit(1);
+}
+
+console.log(
+  'Release notes gate passed: NZ stable and Australian prerelease/planned release language is guarded.'
+);


### PR DESCRIPTION
## Summary
- add a release notes gate that enforces NZ stable versus Australian prerelease/planned release language
- wire the gate into CI, stable/next release workflows, and the GitHub Packages mirror workflow
- update Conductor publication/release plans to mark the release-note gate as implemented

## Validation
- corepack pnpm gate:release-notes
- corepack pnpm gate:no-placeholder-legal-data
- corepack pnpm gate:conductor-requirements
- corepack pnpm gate:manifest-docs
- corepack pnpm gate:install-snippets
- corepack pnpm gate:security-provenance
- corepack pnpm typecheck
- corepack pnpm test:run
- corepack pnpm build
- corepack pnpm exec prettier --check .changeset/release-notes-gate.md .github/workflows/ci.yml .github/workflows/release-stable.yml .github/workflows/release-next.yml .github/workflows/publish-github-packages.yml conductor/tracks/anz-platform-release-and-distribution/plan.md conductor/tracks/anz-publication-package-registries/plan.md package.json scripts/check-release-notes.ts