### PR TITLE
ci: add package metadata gate

### DIFF
--- a/.changeset/package-metadata-gate.md
+++ b/.changeset/package-metadata-gate.md
@@ -1,0 +1,5 @@
+---
+'nz-legislation-tool': patch
+---
+
+Add a package metadata gate and transitional ANZ command aliases while preserving the stable NZ package identity and Australian prerelease/planned support posture.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -238,6 +238,31 @@ jobs:
 
       - name: Run release notes gate
         run: pnpm gate:release-notes
+  package-metadata:
+    name: Package Metadata Gate
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v5
+
+      - name: Enable pnpm via Corepack
+        run: |
+          corepack enable
+          corepack prepare pnpm@10.29.3 --activate
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: '20'
+          cache: 'pnpm'
+
+      - name: Install dependencies
+        run: pnpm install --no-frozen-lockfile
+
+      - name: Run package metadata gate
+        run: pnpm gate:package-metadata
   test:
     name: Test (Node ${{ matrix.node-version }})
     runs-on: ubuntu-latest
@@ -284,6 +309,7 @@ jobs:
         install-snippets,
         security-provenance,
         release-notes,
+        package-metadata,
         test,
       ]
 

--- a/.github/workflows/publish-github-packages.yml
+++ b/.github/workflows/publish-github-packages.yml
@@ -48,6 +48,7 @@ jobs:
           pnpm gate:install-snippets
           pnpm gate:security-provenance
           pnpm gate:release-notes
+          pnpm gate:package-metadata
       - name: Build package
         run: pnpm run build
 

--- a/.github/workflows/release-next.yml
+++ b/.github/workflows/release-next.yml
@@ -63,6 +63,7 @@ jobs:
           pnpm gate:install-snippets
           pnpm gate:security-provenance
           pnpm gate:release-notes
+          pnpm gate:package-metadata
           pnpm typecheck
           pnpm test:run
           pnpm build

--- a/.github/workflows/release-stable.yml
+++ b/.github/workflows/release-stable.yml
@@ -64,6 +64,7 @@ jobs:
           pnpm gate:install-snippets
           pnpm gate:security-provenance
           pnpm gate:release-notes
+          pnpm gate:package-metadata
           pnpm typecheck
           pnpm test:run
           pnpm build

--- a/conductor/tracks/anz-publication-package-registries/plan.md
+++ b/conductor/tracks/anz-publication-package-registries/plan.md
@@ -8,12 +8,14 @@
 - [x] Add this Conductor track.
 - [x] Add release-note checks that reject premature Australian stable-support
       claims and require prerelease/planned language for AU-scoped changesets.
+- [x] Add package metadata checks that preserve package identity, stable command
+      names, transitional ANZ aliases, and NZ-stable/AU-prerelease claims.
 
 ## Phase 2: Publication readiness
 
 **Status:** Pending.
 
-- [ ] Verify npm stable and prerelease metadata.
+- [x] Verify npm stable and prerelease metadata.
 - [ ] Verify GitHub Packages provenance expectations.
 - [x] Verify GitHub Release note template distinguishes NZ stable from AU
       prerelease support.

--- a/docs/maintainers/package-metadata-review.md
+++ b/docs/maintainers/package-metadata-review.md
@@ -1,0 +1,24 @@
+# Package Metadata Review
+
+Status: preparation only; blocked for external publication until all
+release/submission gates pass.
+
+## Package identity
+
+- `nz-legislation-tool` remains the npm package name.
+- `nzlegislation` and `nzlegislation-mcp` remain the stable documented command
+  names.
+- `anzlegislation` and `anzlegislation-mcp` are transitional compatibility
+  aliases while the ANZ transition is incomplete.
+- The repository, issue tracker, homepage, license, files list, and package
+  entry points must continue to match `package.json`.
+
+## Capability claims
+
+New Zealand support is the stable runtime support claim. Australian support
+remains prerelease, planned, or unsupported unless the provider capability
+manifest and release gates promote a jurisdiction.
+
+Registry, marketplace, website, assistant, IDE, Docker/GHCR, Homebrew, and MCP
+listing copy must match this package identity and capability posture before any
+external submission or publication.

--- a/package.json
+++ b/package.json
@@ -6,7 +6,9 @@
   "main": "dist/cli.js",
   "bin": {
     "nzlegislation": "./dist/cli.js",
-    "nzlegislation-mcp": "./dist/mcp-cli.js"
+    "nzlegislation-mcp": "./dist/mcp-cli.js",
+    "anzlegislation": "./dist/cli.js",
+    "anzlegislation-mcp": "./dist/mcp-cli.js"
   },
   "scripts": {
     "dev": "tsx src/cli.ts",
@@ -39,7 +41,8 @@
     "gate:manifest-docs": "tsx scripts/check-manifest-docs-drift.ts",
     "gate:install-snippets": "tsx scripts/check-install-snippets.ts",
     "gate:security-provenance": "tsx scripts/check-security-provenance.ts",
-    "gate:release-notes": "tsx scripts/check-release-notes.ts"
+    "gate:release-notes": "tsx scripts/check-release-notes.ts",
+    "gate:package-metadata": "tsx scripts/check-package-metadata.ts"
   },
   "keywords": [
     "nz",

--- a/scripts/check-install-snippets.ts
+++ b/scripts/check-install-snippets.ts
@@ -10,7 +10,7 @@ const packageJson = JSON.parse(read('package.json')) as PackageJson;
 const bins = packageJson.bin ?? {};
 const failures: string[] = [];
 
-const requiredBins = ['nzlegislation', 'nzlegislation-mcp'];
+const requiredBins = ['nzlegislation', 'nzlegislation-mcp', 'anzlegislation', 'anzlegislation-mcp'];
 for (const bin of requiredBins) {
   if (!bins[bin]) {
     failures.push(`package.json is missing required bin ${bin}.`);

--- a/scripts/check-package-metadata.ts
+++ b/scripts/check-package-metadata.ts
@@ -1,0 +1,205 @@
+import { existsSync, readFileSync } from 'node:fs';
+
+interface PackageJson {
+  name?: string;
+  version?: string;
+  description?: string;
+  type?: string;
+  main?: string;
+  bin?: Record<string, string>;
+  files?: string[];
+  keywords?: string[];
+  license?: string;
+  repository?: { type?: string; url?: string };
+  bugs?: { url?: string };
+  homepage?: string;
+  scripts?: Record<string, string>;
+}
+
+const read = (path: string): string => readFileSync(path, 'utf8');
+const failures: string[] = [];
+const normalize = (value: string): string => value.replace(/\s+/g, ' ').trim();
+
+function requireIncludes(path: string, needles: string[]): void {
+  const content = normalize(read(path));
+  for (const needle of needles) {
+    if (!content.includes(normalize(needle))) {
+      failures.push(`${path} is missing required text: ${needle}`);
+    }
+  }
+}
+
+function rejectPattern(path: string, pattern: RegExp, reason: string): void {
+  const content = read(path);
+  if (pattern.test(content)) {
+    failures.push(`${path} contains forbidden metadata/listing language: ${reason}`);
+  }
+}
+
+const packageJson = JSON.parse(read('package.json')) as PackageJson;
+
+const expectedPackageFields: Array<[keyof PackageJson, string]> = [
+  ['name', 'nz-legislation-tool'],
+  ['description', 'CLI tool for searching and retrieving New Zealand legislation data'],
+  ['type', 'module'],
+  ['main', 'dist/cli.js'],
+  ['license', 'Apache-2.0'],
+  ['homepage', 'https://github.com/edithatogo/nz-legislation#readme'],
+];
+
+for (const [field, expected] of expectedPackageFields) {
+  if (packageJson[field] !== expected) {
+    failures.push(`package.json ${String(field)} must be ${expected}.`);
+  }
+}
+
+if (!packageJson.version || !/^\d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+)?$/.test(packageJson.version)) {
+  failures.push('package.json version must be valid semver.');
+}
+
+const expectedBins: Record<string, string> = {
+  nzlegislation: './dist/cli.js',
+  'nzlegislation-mcp': './dist/mcp-cli.js',
+  anzlegislation: './dist/cli.js',
+  'anzlegislation-mcp': './dist/mcp-cli.js',
+};
+
+for (const [bin, expectedPath] of Object.entries(expectedBins)) {
+  if (packageJson.bin?.[bin] !== expectedPath) {
+    failures.push(`package.json bin ${bin} must point to ${expectedPath}.`);
+  }
+}
+
+for (const file of ['dist', 'README.md', 'LICENSE']) {
+  if (!packageJson.files?.includes(file)) {
+    failures.push(`package.json files must include ${file}.`);
+  }
+}
+
+for (const keyword of [
+  'nz',
+  'legislation',
+  'cli',
+  'legal-tech',
+  'research',
+  'new-zealand',
+  'api',
+]) {
+  if (!packageJson.keywords?.includes(keyword)) {
+    failures.push(`package.json keywords must include ${keyword}.`);
+  }
+}
+
+if (packageJson.repository?.type !== 'git') {
+  failures.push('package.json repository.type must be git.');
+}
+
+if (packageJson.repository?.url !== 'https://github.com/edithatogo/nz-legislation.git') {
+  failures.push('package.json repository.url must point at edithatogo/nz-legislation.git.');
+}
+
+if (packageJson.bugs?.url !== 'https://github.com/edithatogo/nz-legislation/issues') {
+  failures.push('package.json bugs.url must point at repository issues.');
+}
+
+if (packageJson.scripts?.['gate:package-metadata'] !== 'tsx scripts/check-package-metadata.ts') {
+  failures.push(
+    'package.json must define gate:package-metadata as tsx scripts/check-package-metadata.ts'
+  );
+}
+
+const requiredDocs = [
+  'docs/maintainers/package-metadata-review.md',
+  'conductor/tracks/anz-platform-release-and-distribution/release-submission-gates.md',
+  'conductor/tracks/anz-publication-package-registries/spec.md',
+  'conductor/requirements.md',
+  'README.md',
+];
+
+for (const path of requiredDocs) {
+  if (!existsSync(path)) {
+    failures.push(`Missing package/listing metadata document: ${path}`);
+  }
+}
+
+requireIncludes('docs/maintainers/package-metadata-review.md', [
+  'Status: preparation only; blocked for external publication until all release/submission gates pass.',
+  '`nz-legislation-tool` remains the npm package name.',
+  '`nzlegislation` and `nzlegislation-mcp` remain the stable documented command names.',
+  '`anzlegislation` and `anzlegislation-mcp` are transitional compatibility aliases while the ANZ transition is incomplete.',
+  'New Zealand support is the stable runtime support claim.',
+  'Australian support remains prerelease, planned, or unsupported unless the provider capability manifest and release gates promote a jurisdiction.',
+]);
+
+requireIncludes(
+  'conductor/tracks/anz-platform-release-and-distribution/release-submission-gates.md',
+  [
+    'Accurate package metadata',
+    '`package.json`, README, registry metadata, binaries, aliases, and deprecation/prerelease language match runtime capability.',
+  ]
+);
+
+requireIncludes('conductor/tracks/anz-publication-package-registries/spec.md', [
+  'Preserve stable package and binary compatibility names.',
+  'Keep ANZ aliases transitional until migration policy changes.',
+  'stable claims are NZ-only unless a provider is promoted through all gates.',
+]);
+
+requireIncludes('conductor/requirements.md', [
+  'Preserve `nz-legislation-tool`, `nzlegislation`, and `nzlegislation-mcp` compatibility.',
+  'Keep `anzlegislation` and `anzlegislation-mcp` as compatibility aliases while the ANZ transition is incomplete.',
+]);
+
+requireIncludes('README.md', [
+  'npm install -g nz-legislation-tool',
+  'nzlegislation search --query "health act"',
+  'nzlegislation-mcp',
+]);
+
+for (const workflow of [
+  '.github/workflows/ci.yml',
+  '.github/workflows/release-stable.yml',
+  '.github/workflows/release-next.yml',
+  '.github/workflows/publish-github-packages.yml',
+]) {
+  requireIncludes(workflow, ['pnpm gate:package-metadata']);
+}
+
+const prematureClaims = [
+  {
+    pattern: /\bAustralian\s+(?:runtime\s+)?support\s+(?:is\s+)?stable\b/i,
+    reason: 'Australian support must not be described as stable package support.',
+  },
+  {
+    pattern: /\bstable\s+Australian\s+(?:runtime\s+)?support\b/i,
+    reason: 'Australian support must remain prerelease/planned until release gates pass.',
+  },
+  {
+    pattern: /\bproduction-ready\s+Australian\s+(?:runtime\s+)?support\b/i,
+    reason: 'Australian support is not production-ready.',
+  },
+];
+
+for (const path of [
+  'docs/maintainers/package-metadata-review.md',
+  'conductor/tracks/anz-publication-package-registries/spec.md',
+  'README.md',
+]) {
+  if (existsSync(path)) {
+    for (const { pattern, reason } of prematureClaims) {
+      rejectPattern(path, pattern, reason);
+    }
+  }
+}
+
+if (failures.length > 0) {
+  console.error('Package metadata gate failed:');
+  for (const failure of failures) {
+    console.error(`- ${failure}`);
+  }
+  process.exit(1);
+}
+
+console.log(
+  'Package metadata gate passed: package identity, bins, aliases, and listing claims are guarded.'
+);

--- a/scripts/check-security-provenance.ts
+++ b/scripts/check-security-provenance.ts
@@ -68,6 +68,8 @@ const releaseGateCommands = [
   'pnpm gate:manifest-docs',
   'pnpm gate:install-snippets',
   'pnpm gate:security-provenance',
+  'pnpm gate:release-notes',
+  'pnpm gate:package-metadata',
   'pnpm typecheck',
   'pnpm test:run',
   'pnpm build',
@@ -88,6 +90,7 @@ for (const workflow of [
 requireIncludes('.github/workflows/publish-github-packages.yml', [
   'packages: write',
   'pnpm gate:security-provenance',
+  'pnpm gate:package-metadata',
   'pnpm gate:install-snippets',
   'pnpm gate:manifest-docs',
   'pnpm run build',


### PR DESCRIPTION
## Summary
- add a package metadata gate for package identity, repository metadata, files, bins, aliases, and listing claims
- add transitional nzlegislation and nzlegislation-mcp package bin aliases while preserving 
z-legislation-tool, 
zlegislation, and 
zlegislation-mcp
- wire the gate into CI and release/publish workflows and update the publication track status

## Validation
- corepack pnpm gate:package-metadata
- corepack pnpm gate:no-placeholder-legal-data
- corepack pnpm gate:conductor-requirements
- corepack pnpm gate:manifest-docs
- corepack pnpm gate:install-snippets
- corepack pnpm gate:security-provenance
- corepack pnpm gate:release-notes
- corepack pnpm typecheck
- corepack pnpm test:run
- corepack pnpm build
- corepack pnpm audit --audit-level moderate
- corepack pnpm exec prettier --check .changeset/package-metadata-gate.md .github/workflows/ci.yml .github/workflows/release-stable.yml .github/workflows/release-next.yml .github/workflows/publish-github-packages.yml conductor/tracks/anz-publication-package-registries/plan.md docs/maintainers/package-metadata-review.md package.json scripts/check-package-metadata.ts scripts/check-install-snippets.ts scripts/check-security-provenance.ts