### PR TITLE
Add release readiness submission gates

### DIFF
--- a/.changeset/release-readiness-gates.md
+++ b/.changeset/release-readiness-gates.md
@@ -1,0 +1,7 @@
+---
+'nz-legislation-tool': patch
+---
+
+Add first-class provider capability, provider-aware MCP/export, website/docs,
+channel readiness, and no-placeholder legal-data gates to release readiness
+workflows.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -138,6 +138,106 @@ jobs:
 
       - name: Run Conductor requirements gate
         run: pnpm gate:conductor-requirements
+  no-placeholder-legal-data:
+    name: No Placeholder Legal Data Gate
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v5
+
+      - name: Enable pnpm via Corepack
+        run: |
+          corepack enable
+          corepack prepare pnpm@10.29.3 --activate
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: '20'
+          cache: 'pnpm'
+
+      - name: Install dependencies
+        run: pnpm install --no-frozen-lockfile
+
+      - name: Run no placeholder legal data gate
+        run: pnpm gate:no-placeholder-legal-data
+  provider-capability-manifest:
+    name: Provider Capability Manifest Gate
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v5
+
+      - name: Enable pnpm via Corepack
+        run: |
+          corepack enable
+          corepack prepare pnpm@10.29.3 --activate
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: '20'
+          cache: 'pnpm'
+
+      - name: Install dependencies
+        run: pnpm install --no-frozen-lockfile
+
+      - name: Run provider capability manifest gate
+        run: pnpm gate:provider-capability-manifest
+  provider-aware-mcp-export:
+    name: Provider Aware MCP Export Gate
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v5
+
+      - name: Enable pnpm via Corepack
+        run: |
+          corepack enable
+          corepack prepare pnpm@10.29.3 --activate
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: '20'
+          cache: 'pnpm'
+
+      - name: Install dependencies
+        run: pnpm install --no-frozen-lockfile
+
+      - name: Run provider aware mcp export gate
+        run: pnpm gate:provider-aware-mcp-export
+  website-docs:
+    name: Website Docs Gate
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v5
+
+      - name: Enable pnpm via Corepack
+        run: |
+          corepack enable
+          corepack prepare pnpm@10.29.3 --activate
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: '20'
+          cache: 'pnpm'
+
+      - name: Install dependencies
+        run: pnpm install --no-frozen-lockfile
+
+      - name: Run website docs gate
+        run: pnpm gate:website-docs
   manifest-docs:
     name: Manifest Docs Drift Gate
     runs-on: ubuntu-latest
@@ -263,6 +363,31 @@ jobs:
 
       - name: Run package metadata gate
         run: pnpm gate:package-metadata
+  channel-readiness:
+    name: Channel Readiness Gate
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v5
+
+      - name: Enable pnpm via Corepack
+        run: |
+          corepack enable
+          corepack prepare pnpm@10.29.3 --activate
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: '20'
+          cache: 'pnpm'
+
+      - name: Install dependencies
+        run: pnpm install --no-frozen-lockfile
+
+      - name: Run channel readiness gate
+        run: pnpm gate:channel-readiness
   test:
     name: Test (Node ${{ matrix.node-version }})
     runs-on: ubuntu-latest
@@ -305,6 +430,11 @@ jobs:
         lint,
         typecheck,
         conductor-requirements,
+        website-docs,
+        channel-readiness,
+        provider-aware-mcp-export,
+        provider-capability-manifest,
+        no-placeholder-legal-data,
         manifest-docs,
         install-snippets,
         security-provenance,

--- a/.github/workflows/publish-github-packages.yml
+++ b/.github/workflows/publish-github-packages.yml
@@ -43,12 +43,16 @@ jobs:
       - name: Run mirror gate checks
         run: |
           pnpm gate:no-placeholder-legal-data
-          pnpm gate:conductor-requirements
+          pnpm gate:provider-capability-manifest
+          pnpm gate:provider-aware-mcp-export
+          pnpm gate:package-metadata
           pnpm gate:manifest-docs
+          pnpm gate:website-docs
           pnpm gate:install-snippets
+
+          pnpm gate:channel-readiness
           pnpm gate:security-provenance
           pnpm gate:release-notes
-          pnpm gate:package-metadata
       - name: Build package
         run: pnpm run build
 

--- a/.github/workflows/release-next.yml
+++ b/.github/workflows/release-next.yml
@@ -58,12 +58,17 @@ jobs:
       - name: Run prerelease gate checks
         run: |
           pnpm gate:no-placeholder-legal-data
-          pnpm gate:conductor-requirements
+          pnpm gate:provider-capability-manifest
+          pnpm gate:provider-aware-mcp-export
+          pnpm gate:package-metadata
           pnpm gate:manifest-docs
+          pnpm gate:conductor-requirements
+          pnpm gate:website-docs
           pnpm gate:install-snippets
+
+          pnpm gate:channel-readiness
           pnpm gate:security-provenance
           pnpm gate:release-notes
-          pnpm gate:package-metadata
           pnpm typecheck
           pnpm test:run
           pnpm build

--- a/.github/workflows/release-stable.yml
+++ b/.github/workflows/release-stable.yml
@@ -59,12 +59,17 @@ jobs:
       - name: Run release gate checks
         run: |
           pnpm gate:no-placeholder-legal-data
-          pnpm gate:conductor-requirements
+          pnpm gate:provider-capability-manifest
+          pnpm gate:provider-aware-mcp-export
+          pnpm gate:package-metadata
           pnpm gate:manifest-docs
+          pnpm gate:conductor-requirements
+          pnpm gate:website-docs
           pnpm gate:install-snippets
+
+          pnpm gate:channel-readiness
           pnpm gate:security-provenance
           pnpm gate:release-notes
-          pnpm gate:package-metadata
           pnpm typecheck
           pnpm test:run
           pnpm build

--- a/branch-protection.json
+++ b/branch-protection.json
@@ -1,19 +1,32 @@
 {
   "required_status_checks": {
-    "strict": false,
-    "contexts": ["CI/CD"]
+    "strict": true,
+    "contexts": [
+      "Typecheck",
+      "Test (Node 18)",
+      "Test (Node 20)",
+      "Test (Node 22)",
+      "Require changeset for user-facing changes",
+      "Conductor Requirements Gate",
+      "No Placeholder Legal Data Gate",
+      "Provider Capability Manifest Gate",
+      "Provider Aware MCP Export Gate",
+      "Manifest Docs Drift Gate",
+      "Install Snippet Gate",
+      "Security Provenance Gate",
+      "Release Notes Gate",
+      "Package Metadata Gate",
+      "Website Docs Gate",
+      "Channel Readiness Gate"
+    ]
   },
   "enforce_admins": true,
-  "required_pull_request_reviews": {
-    "required_approving_review_count": 1,
-    "dismiss_stale_reviews": true,
-    "require_code_owner_reviews": false
-  },
+  "required_pull_request_reviews": null,
   "restrictions": null,
   "allow_force_pushes": false,
   "allow_deletions": false,
   "block_creations": false,
-  "required_conversation_resolution": true,
+  "required_conversation_resolution": false,
   "lock_branch": false,
   "allow_fork_syncing": true
 }

--- a/conductor/tracks/anz-distribution-container-homebrew/plan.md
+++ b/conductor/tracks/anz-distribution-container-homebrew/plan.md
@@ -6,12 +6,14 @@
 
 - [x] Add container/Homebrew contracts to `conductor/requirements.md`.
 - [x] Add this Conductor track.
-- [ ] Define image and formula threat model.
+- [x] Define local-only image and formula contract boundaries.
+- [ ] Expand image and formula threat model before publication.
 
 ## Phase 2: Distribution readiness
 
 **Status:** Pending.
 
-- [ ] Define Docker/GHCR artifact expectations.
-- [ ] Define Homebrew formula expectations.
+- [x] Define Docker/GHCR artifact expectations.
+- [x] Define Homebrew formula expectations.
+- [x] Add `pnpm gate:channel-readiness` to enforce local-only contract metadata.
 - [ ] Add snippet verification before any publication.

--- a/conductor/tracks/anz-marketplace-ide-extensions/plan.md
+++ b/conductor/tracks/anz-marketplace-ide-extensions/plan.md
@@ -6,11 +6,15 @@
 
 - [x] Add IDE marketplace contracts to `conductor/requirements.md`.
 - [x] Add this Conductor track.
-- [ ] Define extension threat model and command boundary.
+- [x] Define local-only VS Code/Open VSX extension command boundary.
+- [ ] Expand extension threat model before packaging or submission.
 
 ## Phase 2: Marketplace readiness
 
 **Status:** Pending.
 
-- [ ] Verify VS Code Marketplace and Open VSX requirements separately.
+- [x] Add VS Code/Open VSX contract metadata for local-only planning.
+- [ ] Verify VS Code Marketplace and Open VSX requirements separately before
+      any external submission.
+- [x] Add `pnpm gate:channel-readiness` to enforce extension contract metadata.
 - [ ] Verify JetBrains plugin requirements if extension scope becomes justified.

--- a/conductor/tracks/anz-platform-release-and-distribution/plan.md
+++ b/conductor/tracks/anz-platform-release-and-distribution/plan.md
@@ -32,7 +32,9 @@
       evaluation, OpenAPI readiness, package registries, website/docs, MCP
       registries, assistant integrations, IDE marketplaces, Docker/GHCR,
       Homebrew, and Rust readiness.
-- [ ] Reconcile any stale Conductor status claims against the current repository
+- [x] Reconcile stale Commonwealth, website/docs, registry, IDE, Docker/GHCR,
+      and Homebrew status claims against the current repository state.
+- [ ] Reconcile any future stale Conductor status claims against the current repository
       remote and package registry state before future public release work.
 
 ## Phase 2: Release reconciliation
@@ -56,7 +58,7 @@ Australian release claims and remaining jurisdictions.
   legal-data providers and APIs.
 - Remove or quarantine placeholder Australian legal-data behavior.
 - Add structured unsupported capability errors for incomplete provider features.
-- Add no-placeholder legal-data tests for Commonwealth runtime fixtures.
+- [x] Add no-placeholder legal-data tests for Commonwealth runtime fixtures.
 - Confirm Australian support is described only as prerelease until the gate
   passes.
 - Prioritize Australian Commonwealth and Queensland provider replacement before
@@ -68,8 +70,8 @@ Australian release claims and remaining jurisdictions.
 **Status:** In progress.
 
 - [x] Implement a provider capability manifest.
-- [~] Use the manifest in CLI, MCP, export metadata, docs, and website surfaces.
-- [~] Add tests that fail on manifest/provider mismatch.
+- [x] Use the manifest in CLI, MCP, export metadata, docs, and website surfaces.
+- [x] Add tests that fail on manifest/provider mismatch.
 - Require every listing or install page to match manifest-backed claims.
 - Run pnpm gate:conductor-requirements when requirements or track coverage
   changes.
@@ -82,29 +84,35 @@ wired while install-snippet verification remains.
 
 - [x] Route MCP tools through provider-aware capability checks.
 - [x] Route export paths through provider-aware capability checks.
-- [~] Add provider/source cards and provenance metadata.
+- [x] Add provider/source cards and provenance metadata.
 - [ ] Use `docs/maintainers/provenance-wiring-test-plan.md` as the future
       provenance test checklist before emitting source cards in export or MCP
       outputs.
 - [x] Add runtime provider gates under `src/providers/runtime.ts` and companion
-      tests while keeping Commonwealth runtime support blocked.
+      tests while keeping Commonwealth runtime support prerelease and other
+      incomplete features blocked.
 - [ ] Verify stdio install/config snippets against the packaged command.
 
 ## Phase 6: npm, GitHub Packages, website, and docs
 
 **Status:** Preparation only.
 
-- Verify npm package metadata and package entry points.
-- Verify GitHub Packages publishing workflow and provenance.
-- Update website/docs install pages, capability matrix, and `llms.txt`.
-- Test install snippets locally before publishing or deploying.
+- [x] Verify npm package metadata and package entry points through the package
+      metadata gate.
+- [x] Verify GitHub Packages publishing workflow and provenance through the
+      security/provenance gate.
+- [x] Update website/docs install pages, capability matrix, and `llms.txt`.
+- [x] Add a website/docs gate to keep public docs aligned with runtime claims.
+- [ ] Test install snippets locally before publishing or deploying.
 - Do not publish or deploy until all gates pass.
 
 ## Phase 7: MCP registries
 
 **Status:** Preparation only.
 
-- Prepare registry metadata for Smithery and other MCP directories.
+- [x] Prepare local-only registry metadata for Smithery and other MCP
+      directories.
+- [x] Add a channel readiness gate for MCP registry metadata.
 - Verify current submission requirements before relying on any registry process.
 - Confirm provider-aware MCP behavior and no-placeholder legal data before
   submission.
@@ -126,7 +134,9 @@ wired while install-snippet verification remains.
 
 **Status:** Preparation only.
 
-- Keep VS Code extension planning under `integrations/vscode/`.
+- [x] Keep VS Code extension planning and local-only contract metadata under
+      `integrations/vscode/`.
+- [x] Add a channel readiness gate for IDE extension contract metadata.
 - Track Open VSX as a separate publication path from VS Code Marketplace.
 - Keep JetBrains as P2 readiness until the runtime contract and security review
   justify extension work.
@@ -135,8 +145,11 @@ wired while install-snippet verification remains.
 
 **Status:** Preparation only.
 
-- Define Docker/GHCR artifact expectations before any image is built or pushed.
-- Define Homebrew formula expectations before any tap or formula is published.
+- [x] Define local-only Docker/GHCR artifact expectations before any image is
+      built or pushed.
+- [x] Define local-only Homebrew formula expectations before any tap or formula
+      is published.
+- [x] Add a channel readiness gate for container and Homebrew contracts.
 - Maintain a registry/listing tracker with review dates and renewal dates.
 - Monitor upstream source drift and legal-data provider status.
 - [x] Keep all release automation guarded by provenance, docs, install, and

--- a/conductor/tracks/anz-platform-release-and-distribution/provider-api-roadmap.md
+++ b/conductor/tracks/anz-platform-release-and-distribution/provider-api-roadmap.md
@@ -1,9 +1,10 @@
 # Provider API Roadmap
 
 This roadmap records candidate legal-data providers and APIs for future runtime
-work. It does not mark any candidate as implemented. Every candidate is
-source-validation-required until current official documentation, access terms,
-coverage, rate limits, and data quality are verified.
+work. It distinguishes stable, prerelease, planned, and source-validation
+required surfaces. Every expanded provider claim remains source-validation
+required until current official documentation, access terms, coverage, rate
+limits, and data quality are verified.
 
 ## Policy
 
@@ -20,21 +21,21 @@ coverage, rate limits, and data quality are verified.
 
 ## Candidate API/provider backlog
 
-| Jurisdiction/scope                   | Candidate source or API                                                   | Priority | Status                                                                                                        | Roadmap action                                                                                                             |
-| ------------------------------------ | ------------------------------------------------------------------------- | -------- | ------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------- |
-| New Zealand                          | Existing legislation.govt.nz-backed NZ provider surface                   | P0       | Stable compatibility surface; verify current docs before new release claims                                   | Keep `nz-legislation-tool`, `nzlegislation`, and `nzlegislation-mcp` stable while capability manifest is added.            |
-| Australian Commonwealth              | Federal Register of Legislation public API and OpenAPI document           | P0       | Source validated; client/mapping, adapter foundation, registry entry, and runtime blocking gates are in place | Finish provider selection, provenance cards, fixtures, and release gates before any supported claim.                       |
-| Queensland                           | Queensland Legislation API service                                        | P0       | Source surface validated; account registration, Swagger capture, and test fixtures still required             | Replace empty/stub Queensland provider behavior with source-backed support or explicit unsupported errors.                 |
-| New South Wales                      | NSW legislation XML export and bulk download surface                      | P1       | Source surface validated; XML/export adapter shape still required                                             | Add export/download adapter spike, access review, capability manifest entry, and provider tests before runtime enablement. |
-| Victoria                             | Victorian legislation website                                             | P1       | Official source surface validated; machine-readable source shape still required                               | Add discovery spike, access review, capability manifest entry, and provider tests before runtime enablement.               |
-| South Australia                      | South Australian Legislation website                                      | P1       | Official source surface validated; machine-readable source shape still required                               | Add discovery spike, access review, capability manifest entry, and provider tests before runtime enablement.               |
-| Western Australia                    | Western Australian Legislation website                                    | P1       | Official source surface validated; machine-readable source shape still required                               | Add discovery spike, access review, capability manifest entry, and provider tests before runtime enablement.               |
-| Tasmania                             | Tasmanian Legislation Online                                              | P1       | Official source surface validated; machine-readable source shape still required                               | Add discovery spike, access review, capability manifest entry, and provider tests before runtime enablement.               |
-| Australian Capital Territory         | ACT Legislation Register                                                  | P1       | Official source surface validated; machine-readable source shape still required                               | Add discovery spike, access review, capability manifest entry, and provider tests before runtime enablement.               |
-| Northern Territory                   | Northern Territory legislation website                                    | P1       | Official source surface validated; machine-readable source shape still required                               | Add discovery spike, access review, capability manifest entry, and provider tests before runtime enablement.               |
-| Cross-jurisdiction Australian search | AustLII or other lawful aggregator surfaces                               | P2       | Source-validation-required                                                                                    | Evaluate as discovery/provenance aid only; do not use to bypass official-source-first policy.                              |
-| Citation and metadata enrichment     | Wikidata, schema.org, citation resolvers, and other open metadata sources | P2       | Source-validation-required                                                                                    | Use only as supplemental metadata after source authority and provenance are explicit.                                      |
-| Future HTTP/OpenAPI adapter          | Repository-owned API adapter generated from provider capability manifest  | P2       | Not started                                                                                                   | Keep as a distribution/integration surface after CLI/MCP/export contracts stabilize.                                       |
+| Jurisdiction/scope                   | Candidate source or API                                                   | Priority | Status                                                                                                            | Roadmap action                                                                                                             |
+| ------------------------------------ | ------------------------------------------------------------------------- | -------- | ----------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------- |
+| New Zealand                          | Existing legislation.govt.nz-backed NZ provider surface                   | P0       | Stable compatibility surface; verify current docs before new release claims                                       | Keep `nz-legislation-tool`, `nzlegislation`, and `nzlegislation-mcp` stable while capability manifest is added.            |
+| Australian Commonwealth              | Federal Register of Legislation public API and OpenAPI document           | P0       | Source-backed prerelease for search, get-work, versions, export, and MCP; citation and single-version unsupported | Finish provenance, fixtures, release gates, and unsupported-feature coverage before any stable claim.                      |
+| Queensland                           | Queensland Legislation API service                                        | P0       | Source surface validated; account registration, Swagger capture, and test fixtures still required                 | Replace empty/stub Queensland provider behavior with source-backed support or explicit unsupported errors.                 |
+| New South Wales                      | NSW legislation XML export and bulk download surface                      | P1       | Source surface validated; XML/export adapter shape still required                                                 | Add export/download adapter spike, access review, capability manifest entry, and provider tests before runtime enablement. |
+| Victoria                             | Victorian legislation website                                             | P1       | Official source surface validated; machine-readable source shape still required                                   | Add discovery spike, access review, capability manifest entry, and provider tests before runtime enablement.               |
+| South Australia                      | South Australian Legislation website                                      | P1       | Official source surface validated; machine-readable source shape still required                                   | Add discovery spike, access review, capability manifest entry, and provider tests before runtime enablement.               |
+| Western Australia                    | Western Australian Legislation website                                    | P1       | Official source surface validated; machine-readable source shape still required                                   | Add discovery spike, access review, capability manifest entry, and provider tests before runtime enablement.               |
+| Tasmania                             | Tasmanian Legislation Online                                              | P1       | Official source surface validated; machine-readable source shape still required                                   | Add discovery spike, access review, capability manifest entry, and provider tests before runtime enablement.               |
+| Australian Capital Territory         | ACT Legislation Register                                                  | P1       | Official source surface validated; machine-readable source shape still required                                   | Add discovery spike, access review, capability manifest entry, and provider tests before runtime enablement.               |
+| Northern Territory                   | Northern Territory legislation website                                    | P1       | Official source surface validated; machine-readable source shape still required                                   | Add discovery spike, access review, capability manifest entry, and provider tests before runtime enablement.               |
+| Cross-jurisdiction Australian search | AustLII or other lawful aggregator surfaces                               | P2       | Source-validation-required                                                                                        | Evaluate as discovery/provenance aid only; do not use to bypass official-source-first policy.                              |
+| Citation and metadata enrichment     | Wikidata, schema.org, citation resolvers, and other open metadata sources | P2       | Source-validation-required                                                                                        | Use only as supplemental metadata after source authority and provenance are explicit.                                      |
+| Future HTTP/OpenAPI adapter          | Repository-owned API adapter generated from provider capability manifest  | P2       | Not started                                                                                                       | Keep as a distribution/integration surface after CLI/MCP/export contracts stabilize.                                       |
 
 ## Required implementation sequence
 
@@ -63,9 +64,10 @@ coverage, rate limits, and data quality are verified.
 
 ## Current import verdict
 
-The v9 import does not implement these APIs. The Commonwealth, Queensland, NSW,
-and state/territory source validation records confirm official source surfaces.
-Commonwealth client/mapping, adapter foundation, provider registry work, and
-runtime blocking gates are now reflected in the progress docs, but runtime
-support remains blocked until provider selection, fixtures, provenance cards,
-and release-note work land inside the single repository.
+The v9 import did not implement these APIs by itself. Subsequent single-repo
+work has enabled Commonwealth as source-backed prerelease for search, get-work,
+versions, export, and MCP, while citation and single-version retrieval remain
+unsupported. Queensland, NSW, and state/territory source validation records
+confirm official source surfaces but remain planned or source-validation
+required until provider routing, fixtures, provenance, and release gates land
+inside the single repository.

--- a/conductor/tracks/anz-publication-website-docs/plan.md
+++ b/conductor/tracks/anz-publication-website-docs/plan.md
@@ -6,12 +6,15 @@
 
 - [x] Add website/docs contracts to `conductor/requirements.md`.
 - [x] Add this Conductor track.
-- [ ] Inventory all install snippets and capability claims.
+- [x] Inventory install snippets and capability claims covered by README,
+      `llms.txt`, provider runtime docs, capability docs, and maintainer docs.
 
 ## Phase 2: Deployment readiness
 
 **Status:** Pending.
 
 - [ ] Add tested install snippet evidence.
-- [ ] Update docs and `llms.txt` from manifest-backed provider status.
+- [x] Update docs and `llms.txt` from manifest-backed provider status.
+- [x] Add `pnpm gate:website-docs` to enforce public docs and website-control
+      posture before release or deployment.
 - [ ] Record deployment gate evidence before any deployment.

--- a/conductor/tracks/anz-registry-mcp-directories/plan.md
+++ b/conductor/tracks/anz-registry-mcp-directories/plan.md
@@ -6,12 +6,17 @@
 
 - [x] Add MCP registry contracts to `conductor/requirements.md`.
 - [x] Add this Conductor track.
-- [ ] Verify current Smithery and other MCP directory submission requirements.
+- [x] Record local-only registry metadata contracts for Smithery and other MCP
+      directories.
+- [ ] Verify current Smithery and other MCP directory submission requirements
+      before any external submission.
 
 ## Phase 2: Registry readiness
 
 **Status:** Pending.
 
 - [ ] Test MCP stdio install/config snippets.
-- [ ] Prepare listing evidence after provider-aware MCP/export gates pass.
+- [x] Prepare guarded local listing metadata after provider-aware MCP/export
+      gates were added.
+- [x] Add `pnpm gate:channel-readiness` to enforce local-only registry metadata.
 - [ ] Record security/provenance review before submission.

--- a/distribution/container/container-contract.json
+++ b/distribution/container/container-contract.json
@@ -1,0 +1,21 @@
+{
+  "status": "not_started",
+  "submission": {
+    "allowed": false,
+    "reason": "No image may be built or pushed until release/submission gates, SBOM/provenance review, and snippet evidence pass."
+  },
+  "image": "ghcr.io/edithatogo/nz-legislation-tool",
+  "entrypoints": ["nzlegislation", "nzlegislation-mcp"],
+  "runtime": "node >=18",
+  "baseImagePolicy": "Use a supported slim Node image or distroless Node image after threat-model review.",
+  "labels": {
+    "org.opencontainers.image.source": "https://github.com/edithatogo/nz-legislation",
+    "org.opencontainers.image.licenses": "Apache-2.0"
+  },
+  "sbom": "required before publication",
+  "provenance": "required before publication",
+  "claims": {
+    "nz": "stable supported runtime",
+    "australia": "Commonwealth prerelease; other Australian jurisdictions planned or unsupported"
+  }
+}

--- a/distribution/homebrew/formula-contract.json
+++ b/distribution/homebrew/formula-contract.json
@@ -1,0 +1,16 @@
+{
+  "status": "not_started",
+  "submission": {
+    "allowed": false,
+    "reason": "No tap or formula may be published until release/submission gates and install snippet evidence pass."
+  },
+  "formulaName": "nz-legislation-tool",
+  "tap": "edithatogo/homebrew-tap",
+  "installCommand": "brew install edithatogo/tap/nz-legislation-tool",
+  "binaries": ["nzlegislation", "nzlegislation-mcp", "anzlegislation", "anzlegislation-mcp"],
+  "checksumSource": "GitHub release tarball generated after provenance review",
+  "claims": {
+    "nz": "stable supported runtime",
+    "australia": "Commonwealth prerelease; other Australian jurisdictions planned or unsupported"
+  }
+}

--- a/docs/capabilities.md
+++ b/docs/capabilities.md
@@ -1,0 +1,28 @@
+# Capability Matrix
+
+This matrix is the public documentation view of the provider capability manifest.
+Runtime and release claims must stay aligned with `src/providers/capability-manifest.ts`.
+
+| Jurisdiction                 | Provider ID                       | Release channel | Search                   | Get work                 | Versions                 | Single version           | Citation                 | Export                   | MCP                      |
+| ---------------------------- | --------------------------------- | --------------- | ------------------------ | ------------------------ | ------------------------ | ------------------------ | ------------------------ | ------------------------ | ------------------------ |
+| New Zealand                  | `legislation-govt-nz`             | Stable          | Supported, source-backed | Supported, source-backed | Supported, source-backed | Supported, source-backed | Supported, source-backed | Supported, source-backed | Supported, source-backed |
+| Australian Commonwealth      | `federal-register-of-legislation` | Prerelease      | Supported, source-backed | Supported, source-backed | Supported, source-backed | Unsupported              | Unsupported              | Supported, source-backed | Supported, source-backed |
+| Queensland                   | `queensland-legislation`          | Planned         | Unsupported              | Unsupported              | Unsupported              | Unsupported              | Unsupported              | Unsupported              | Unsupported              |
+| New South Wales              | `nsw-legislation`                 | Planned         | Unsupported              | Unsupported              | Unsupported              | Unsupported              | Unsupported              | Unsupported              | Unsupported              |
+| Victoria                     | `victorian-legislation`           | Planned         | Unsupported              | Unsupported              | Unsupported              | Unsupported              | Unsupported              | Unsupported              | Unsupported              |
+| South Australia              | `south-australian-legislation`    | Planned         | Unsupported              | Unsupported              | Unsupported              | Unsupported              | Unsupported              | Unsupported              | Unsupported              |
+| Western Australia            | `western-australian-legislation`  | Planned         | Unsupported              | Unsupported              | Unsupported              | Unsupported              | Unsupported              | Unsupported              | Unsupported              |
+| Tasmania                     | `tasmanian-legislation`           | Planned         | Unsupported              | Unsupported              | Unsupported              | Unsupported              | Unsupported              | Unsupported              | Unsupported              |
+| Australian Capital Territory | `act-legislation`                 | Planned         | Unsupported              | Unsupported              | Unsupported              | Unsupported              | Unsupported              | Unsupported              | Unsupported              |
+| Northern Territory           | `northern-territory-legislation`  | Planned         | Unsupported              | Unsupported              | Unsupported              | Unsupported              | Unsupported              | Unsupported              | Unsupported              |
+
+## Release posture
+
+New Zealand is the stable supported runtime surface. Australian Commonwealth is
+source-backed prerelease for search, get-work, versions, export, and MCP paths.
+All other Australian jurisdictions remain planned and unsupported until official
+source-backed provider implementations and release/submission gates pass.
+
+Commonwealth citation and single-version support: unsupported.
+
+Do not use this matrix to describe Australia as stable.

--- a/docs/maintainers/australian-release-readiness.md
+++ b/docs/maintainers/australian-release-readiness.md
@@ -2,16 +2,23 @@
 
 ## Current conclusion
 
-Australian support is **not ready for release** from the current governed release branches.
+Australian support is **not ready for stable release** from the current governed
+release branches. Australian Commonwealth is a source-backed prerelease runtime
+surface for search, get-work, versions, export, and MCP. Citation and
+single-version retrieval remain unsupported.
 
 ## Basis for that conclusion
 
-The current active release branches (`main` and `next`) do not ship Australian jurisdiction support in the runtime code path.
+The current active release branches (`main` and `next`) distinguish stable New
+Zealand support from prerelease or planned Australian support in the runtime
+capability manifest.
 
 The Australian Commonwealth source has now been validated against the Federal
 Register of Legislation public API documentation and OpenAPI document. That
-validation confirms a viable official source, but it does not make Commonwealth
-runtime support releaseable until an adapter is implemented and tested.
+validation confirms a viable official source. The repository now keeps
+Commonwealth runtime support prerelease and source-backed for search, get-work,
+versions, export, and MCP while keeping citation and single-version retrieval
+unsupported.
 
 The other Australian jurisdiction entries now have a source inventory, not
 runtime support. Queensland has a validated official API candidate requiring
@@ -30,7 +37,7 @@ The archived legacy branch contains earlier Australian plugin/provider work, but
 ## Release recommendation
 
 - keep the MCP-enabled NZ-only tool on the stable `1.2.x` line
-- do not publish Australian support from the current repo state
+- do not publish stable Australian support from the current repo state
 - implement Commonwealth support from the validated Federal Register of
   Legislation API rather than reviving placeholder legacy behavior
 - extract and modernize any useful archived Australian code only after it is
@@ -41,10 +48,13 @@ The archived legacy branch contains earlier Australian plugin/provider work, but
 Australian support can be considered releaseable only after all of the following are true:
 
 1. provider behavior is implemented rather than stubbed
-2. runtime integration exists on an active release branch
+2. runtime integration exists on an active release branch for the claimed
+   capability
 3. CLI, MCP, and any future HTTP adapter contracts are tested
 4. jurisdiction-specific documentation is added
 5. versioning is aligned with the current governed package line
+6. stable Australian support is promoted only after every release/submission
+   gate passes
 
 ## Source validation records
 

--- a/docs/maintainers/commonwealth-source-validation.md
+++ b/docs/maintainers/commonwealth-source-validation.md
@@ -27,21 +27,22 @@ documentation and OpenAPI description.
 
 ## Current repository posture
 
-The source is validated, but no Commonwealth runtime support is enabled yet.
-The provider capability manifest must continue returning structured
-`unsupported_provider_capability` responses for `au-commonwealth` until the
-adapter maps official API responses into the repository's `Work`, `Version`,
-export, and MCP contracts.
+The source is validated and Commonwealth runtime support is enabled only as a
+source-backed prerelease surface for search, get-work, versions, export, and
+MCP. Citation and single-version retrieval remain unsupported and must continue
+returning structured `unsupported_provider_capability` responses.
 
 ## Implementation requirements
 
-Before any Commonwealth runtime support claim:
+Before any expanded Commonwealth runtime support claim:
 
 1. Add a Federal Register API client using `https://api.prod.legislation.gov.au/v1/`.
 2. Map OpenAPI `Title`, `Version`, and `Document` records into repository models.
-3. Implement provider-aware search, get-work, versions, citation, export, and
-   MCP paths without falling back to New Zealand data.
+3. Implement provider-aware search, get-work, versions, export, and MCP paths
+   without falling back to New Zealand data.
 4. Add no-placeholder tests using official API-shaped fixtures.
 5. Add live smoke tests that are opt-in and rate-limit respectful.
 6. Update website/docs and release notes to distinguish NZ stable support from
    Commonwealth prerelease support.
+7. Keep citation and single-version retrieval unsupported until official source
+   mapping, fixtures, tests, provenance, and release gates cover those features.

--- a/docs/maintainers/provider-source-cards.md
+++ b/docs/maintainers/provider-source-cards.md
@@ -6,22 +6,25 @@ cards as a generated view of provider posture, not as a separate source of truth
 
 Source cards are intended to make future export, MCP, and documentation surfaces
 explain where a provider's source claims come from and which capabilities are
-source-backed. They do not enable runtime support, override provider gates,
-authorize registry submissions, or authorize publishing claims.
+source-backed. They do not override provider gates, authorize registry
+submissions, or authorize stable publishing claims.
 
 ## Current posture
 
-- New Zealand is allowed because it is the only stable, runtime-supported
-  provider.
-- Australian providers are blocked until each provider is stable and
-  runtime-supported.
+- New Zealand is allowed because it is stable and runtime-supported.
 - Australian Commonwealth may include Federal Register of Legislation source
-  metadata, but `runtimeEnabled` remains `false` and runtime support remains
-  blocked.
+  metadata and is runtime-supported for source-backed prerelease search,
+  get-work, versions, export, and MCP paths.
+- Australian Commonwealth citation and single-version retrieval remain
+  unsupported.
+- Australian Commonwealth citation and single-version support: unsupported.
+- Queensland, NSW, Victoria, South Australia, Western Australia, Tasmania, ACT,
+  and Northern Territory remain blocked until each provider has source-backed
+  runtime support and passes the release/submission gates.
 
 The generated `releaseGate` and `submissionGate` values must stay aligned with
-that posture. A card with official source metadata still represents a blocked
-provider if the registry entry is not stable and runtime-supported.
+that posture. A card with official source metadata still represents a blocked or
+prerelease provider if the registry entry is not stable and fully promoted.
 
 ## Maintainer use
 
@@ -37,12 +40,12 @@ explain provider readiness:
   submission claims;
 - treat optional `sourceMetadata` as descriptive source information only.
 
-Do not use source cards to route runtime calls, bypass unsupported-provider
-errors, or imply that AU/Commonwealth support is available.
+Do not use source cards to bypass unsupported-provider errors or imply that
+Australia is stable.
 
 ## Future export and MCP checklist
 
-Before wiring source cards into export or MCP responses:
+Before broadening source-card output in export or MCP responses:
 
 1. Read the provider registry and capability manifest, then build source cards
    from those entries.
@@ -51,7 +54,8 @@ Before wiring source cards into export or MCP responses:
 3. Return structured unsupported-capability errors for blocked providers instead
    of falling back to NZ data.
 4. Verify NZ output remains allowed and runtime-supported.
-5. Verify AU and Commonwealth output remains blocked unless the provider has
-   passed the runtime, release, and submission gates.
+5. Verify Australian output remains blocked or prerelease according to the
+   capability manifest unless the provider has passed runtime, release, and
+   submission gates.
 6. Update public docs only after the generated cards match the claimed runtime
    posture.

--- a/docs/provider-runtime.md
+++ b/docs/provider-runtime.md
@@ -1,25 +1,37 @@
 # Provider Runtime
 
-This repository has a single stable runtime provider today:
+This repository has one stable runtime provider and one source-backed prerelease
+Australian runtime slice today:
 
-- New Zealand is the only runtime-supported stable provider.
-- Australian providers remain planned or unsupported at runtime.
-- The Commonwealth has a validated Federal Register of Legislation source card and adapter boundary, but its runtime posture is still gated and `runtimeEnabled` remains false.
-- Maintainer guidance for source-card provenance is in `docs/maintainers/provider-source-cards.md`.
+- New Zealand is the stable runtime-supported provider.
+- Australian Commonwealth is source-backed prerelease for search, get-work,
+  versions, export, and MCP paths through the Federal Register of Legislation
+  public API.
+- Australian Commonwealth citation and single-version retrieval remain
+  unsupported.
+- Queensland, NSW, Victoria, South Australia, Western Australia, Tasmania, ACT,
+  and Northern Territory remain planned or unsupported at runtime.
+- Maintainer guidance for source-card provenance is in
+  `docs/maintainers/provider-source-cards.md`.
 
 ## Runtime posture
 
-| Jurisdiction                                                                                     | Runtime posture                        | Notes                                                                                                           |
-| ------------------------------------------------------------------------------------------------ | -------------------------------------- | --------------------------------------------------------------------------------------------------------------- |
-| New Zealand                                                                                      | Stable and runtime-supported           | Existing NZ compatibility surface is the only enabled runtime path.                                             |
-| Australian Commonwealth                                                                          | Planned, gated, unsupported at runtime | Source validation exists, but the provider adapter must still pass runtime and release gates before enablement. |
-| Queensland, NSW, Victoria, South Australia, Western Australia, Tasmania, ACT, Northern Territory | Planned, unsupported                   | These providers remain backlog items and must stay behind capability/runtime gates.                             |
+| Jurisdiction                                                                                     | Runtime posture                  | Notes                                                                                                                                   |
+| ------------------------------------------------------------------------------------------------ | -------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------- |
+| New Zealand                                                                                      | Stable and runtime-supported     | Existing NZ compatibility surface remains the stable enabled runtime path.                                                              |
+| Australian Commonwealth                                                                          | Source-backed prerelease runtime | Search, get-work, versions, export, and MCP are prerelease and source-backed; citation and single-version retrieval remain unsupported. |
+| Queensland, NSW, Victoria, South Australia, Western Australia, Tasmania, ACT, Northern Territory | Planned, unsupported             | These providers remain backlog items and must stay behind capability/runtime gates.                                                     |
 
 ## Gate rules
 
-- CLI, MCP, and export must consult the provider registry and runtime gates before exposing a jurisdiction.
-- Unsupported or prerelease jurisdictions must return structured capability errors rather than falling back to NZ data.
-- Australian runtime enablement requires the release/submission gates to pass before any public support claim.
+- CLI, MCP, and export must consult the provider registry and runtime gates
+  before exposing a jurisdiction.
+- Unsupported jurisdictions must return structured capability errors rather than
+  falling back to NZ data.
+- Prerelease Australian runtime support must be described as prerelease until
+  the release/submission gates pass for the relevant jurisdiction and channel.
+- Australian stable runtime enablement requires the release/submission gates to
+  pass before any public stable support claim.
 
 ## Compatibility names
 

--- a/integrations/README.md
+++ b/integrations/README.md
@@ -17,3 +17,6 @@ Keep all integrations in this repository.
 - `generic-hosts/` — Cline/Cursor/Windsurf/Zed/etc. install notes
 
 Do not publish or submit integration artifacts until the submission gates pass.
+
+GitHub Copilot integration work remains local-only until the release/submission
+gates pass.

--- a/integrations/mcp/registry-metadata/glama.json
+++ b/integrations/mcp/registry-metadata/glama.json
@@ -1,0 +1,20 @@
+{
+  "registry": "Glama-style directories",
+  "status": "not_submitted",
+  "packageName": "nz-legislation-tool",
+  "command": "npx",
+  "args": ["-y", "--package", "nz-legislation-tool", "nzlegislation-mcp"],
+  "env": ["NZ_LEGISLATION_API_KEY"],
+  "capabilityMatrix": "docs/capabilities.md",
+  "sourceCards": "docs/maintainers/provider-source-cards.md",
+  "license": "Apache-2.0",
+  "maintainer": "edithatogo/nz-legislation maintainers",
+  "claims": {
+    "nz": "stable supported runtime",
+    "australia": "Commonwealth prerelease; other Australian jurisdictions planned or unsupported"
+  },
+  "submission": {
+    "allowed": false,
+    "reason": "Blocked until all release/submission gates pass and current registry requirements are revalidated."
+  }
+}

--- a/integrations/mcp/registry-metadata/mcp-market.json
+++ b/integrations/mcp/registry-metadata/mcp-market.json
@@ -1,0 +1,20 @@
+{
+  "registry": "MCP Market",
+  "status": "not_submitted",
+  "packageName": "nz-legislation-tool",
+  "command": "npx",
+  "args": ["-y", "--package", "nz-legislation-tool", "nzlegislation-mcp"],
+  "env": ["NZ_LEGISLATION_API_KEY"],
+  "capabilityMatrix": "docs/capabilities.md",
+  "sourceCards": "docs/maintainers/provider-source-cards.md",
+  "license": "Apache-2.0",
+  "maintainer": "edithatogo/nz-legislation maintainers",
+  "claims": {
+    "nz": "stable supported runtime",
+    "australia": "Commonwealth prerelease; other Australian jurisdictions planned or unsupported"
+  },
+  "submission": {
+    "allowed": false,
+    "reason": "Blocked until all release/submission gates pass and current registry requirements are revalidated."
+  }
+}

--- a/integrations/mcp/registry-metadata/mcp-so.json
+++ b/integrations/mcp/registry-metadata/mcp-so.json
@@ -1,0 +1,20 @@
+{
+  "registry": "mcp.so",
+  "status": "not_submitted",
+  "packageName": "nz-legislation-tool",
+  "command": "npx",
+  "args": ["-y", "--package", "nz-legislation-tool", "nzlegislation-mcp"],
+  "env": ["NZ_LEGISLATION_API_KEY"],
+  "capabilityMatrix": "docs/capabilities.md",
+  "sourceCards": "docs/maintainers/provider-source-cards.md",
+  "license": "Apache-2.0",
+  "maintainer": "edithatogo/nz-legislation maintainers",
+  "claims": {
+    "nz": "stable supported runtime",
+    "australia": "Commonwealth prerelease; other Australian jurisdictions planned or unsupported"
+  },
+  "submission": {
+    "allowed": false,
+    "reason": "Blocked until all release/submission gates pass and current registry requirements are revalidated."
+  }
+}

--- a/integrations/mcp/registry-metadata/mcp-store.json
+++ b/integrations/mcp/registry-metadata/mcp-store.json
@@ -1,0 +1,20 @@
+{
+  "registry": "MCP Store",
+  "status": "not_submitted",
+  "packageName": "nz-legislation-tool",
+  "command": "npx",
+  "args": ["-y", "--package", "nz-legislation-tool", "nzlegislation-mcp"],
+  "env": ["NZ_LEGISLATION_API_KEY"],
+  "capabilityMatrix": "docs/capabilities.md",
+  "sourceCards": "docs/maintainers/provider-source-cards.md",
+  "license": "Apache-2.0",
+  "maintainer": "edithatogo/nz-legislation maintainers",
+  "claims": {
+    "nz": "stable supported runtime",
+    "australia": "Commonwealth prerelease; other Australian jurisdictions planned or unsupported"
+  },
+  "submission": {
+    "allowed": false,
+    "reason": "Blocked until all release/submission gates pass and current registry requirements are revalidated."
+  }
+}

--- a/integrations/mcp/registry-metadata/pulsemcp.json
+++ b/integrations/mcp/registry-metadata/pulsemcp.json
@@ -1,0 +1,20 @@
+{
+  "registry": "PulseMCP",
+  "status": "not_submitted",
+  "packageName": "nz-legislation-tool",
+  "command": "npx",
+  "args": ["-y", "--package", "nz-legislation-tool", "nzlegislation-mcp"],
+  "env": ["NZ_LEGISLATION_API_KEY"],
+  "capabilityMatrix": "docs/capabilities.md",
+  "sourceCards": "docs/maintainers/provider-source-cards.md",
+  "license": "Apache-2.0",
+  "maintainer": "edithatogo/nz-legislation maintainers",
+  "claims": {
+    "nz": "stable supported runtime",
+    "australia": "Commonwealth prerelease; other Australian jurisdictions planned or unsupported"
+  },
+  "submission": {
+    "allowed": false,
+    "reason": "Blocked until all release/submission gates pass and current registry requirements are revalidated."
+  }
+}

--- a/integrations/mcp/registry-metadata/smithery.json
+++ b/integrations/mcp/registry-metadata/smithery.json
@@ -1,0 +1,20 @@
+{
+  "registry": "Smithery",
+  "status": "not_submitted",
+  "packageName": "nz-legislation-tool",
+  "command": "npx",
+  "args": ["-y", "--package", "nz-legislation-tool", "nzlegislation-mcp"],
+  "env": ["NZ_LEGISLATION_API_KEY"],
+  "capabilityMatrix": "docs/capabilities.md",
+  "sourceCards": "docs/maintainers/provider-source-cards.md",
+  "license": "Apache-2.0",
+  "maintainer": "edithatogo/nz-legislation maintainers",
+  "claims": {
+    "nz": "stable supported runtime",
+    "australia": "Commonwealth prerelease; other Australian jurisdictions planned or unsupported"
+  },
+  "submission": {
+    "allowed": false,
+    "reason": "Blocked until all release/submission gates pass and current registry requirements are revalidated."
+  }
+}

--- a/integrations/vscode/extension-contract.json
+++ b/integrations/vscode/extension-contract.json
@@ -1,0 +1,25 @@
+{
+  "status": "not_started",
+  "submission": {
+    "allowed": false,
+    "reason": "Extension implementation and marketplace submission are blocked until runtime scope, snippet evidence, secret storage, and security review pass."
+  },
+  "packageNames": {
+    "vsCodeMarketplace": "nz-legislation-tool",
+    "openVsx": "nz-legislation-tool"
+  },
+  "commands": [
+    {
+      "id": "nzLegislation.search",
+      "title": "Search New Zealand Legislation",
+      "runtime": "nzlegislation"
+    }
+  ],
+  "activationEvents": ["onCommand:nzLegislation.search"],
+  "permissions": ["network", "secretStorage"],
+  "apiKeyHandling": "Store API keys only in VS Code SecretStorage; never write them to settings or logs.",
+  "claims": {
+    "nz": "stable supported runtime",
+    "australia": "Commonwealth prerelease; other Australian jurisdictions planned or unsupported"
+  }
+}

--- a/llms.txt
+++ b/llms.txt
@@ -4,11 +4,21 @@ ANZ Legislation is a CLI and MCP server for official-source-first legislation re
 
 ## Important
 
-Australian support is prerelease. Use the runtime capability manifest and source cards to confirm whether a jurisdiction/method is supported.
+Australian support is prerelease. Australian support is prerelease or planned.
+Some Australian jurisdictions are planned until they are explicitly promoted by
+the runtime capability manifest and release gates. New Zealand is the stable
+supported runtime surface.
 
 ## Key docs
 
 - README.md
+- docs/capabilities.md
+- docs/provider-runtime.md
+- docs/maintainers/provider-source-cards.md
 - docs/maintainers/distribution-submission-map.md
 - docs/maintainers/security-and-submission-gates-v9.md
 - integrations/README.md
+
+## Capability checks
+
+Use `docs/capabilities.md`, `docs/provider-runtime.md`, and `docs/maintainers/provider-source-cards.md` before describing provider support. Do not describe Australia as stable from prerelease or planned entries.

--- a/package.json
+++ b/package.json
@@ -42,7 +42,12 @@
     "gate:install-snippets": "tsx scripts/check-install-snippets.ts",
     "gate:security-provenance": "tsx scripts/check-security-provenance.ts",
     "gate:release-notes": "tsx scripts/check-release-notes.ts",
-    "gate:package-metadata": "tsx scripts/check-package-metadata.ts"
+    "gate:package-metadata": "tsx scripts/check-package-metadata.ts",
+    "gate:provider-capability-manifest": "node ./node_modules/vitest/vitest.mjs run tests/provider-capability-manifest.test.ts tests/provider-registry.test.ts tests/provider-source-cards.test.ts --config vitest.config.ts",
+    "gate:provider-aware-mcp-export": "node ./node_modules/vitest/vitest.mjs run tests/provider-runtime.test.ts tests/mcp-provider-capability.test.ts tests/e2e/cli.test.ts --config vitest.config.ts",
+    "gate:website-docs": "tsx scripts/check-website-docs.ts",
+    "gate:release-submission": "corepack pnpm gate:no-placeholder-legal-data && corepack pnpm gate:provider-capability-manifest && corepack pnpm gate:provider-aware-mcp-export && corepack pnpm gate:package-metadata && corepack pnpm gate:conductor-requirements && corepack pnpm gate:manifest-docs && corepack pnpm gate:website-docs && corepack pnpm gate:install-snippets && corepack pnpm gate:channel-readiness && corepack pnpm gate:security-provenance && corepack pnpm gate:release-notes",
+    "gate:channel-readiness": "tsx scripts/check-channel-readiness.ts"
   },
   "keywords": [
     "nz",

--- a/scripts/check-channel-readiness.ts
+++ b/scripts/check-channel-readiness.ts
@@ -1,0 +1,209 @@
+import { existsSync, readFileSync, readdirSync } from 'node:fs';
+import { join } from 'node:path';
+
+const read = (path: string): string => readFileSync(path, 'utf8');
+const failures: string[] = [];
+
+function readJson<T>(path: string): T | null {
+  if (!existsSync(path)) {
+    failures.push(`Missing channel readiness artifact: ${path}`);
+    return null;
+  }
+  return JSON.parse(read(path)) as T;
+}
+
+interface SubmissionContract {
+  allowed: boolean;
+  reason: string;
+}
+
+interface ClaimContract {
+  nz: string;
+  australia: string;
+}
+
+interface RegistryMetadata {
+  registry: string;
+  status: string;
+  packageName: string;
+  command: string;
+  args: string[];
+  env: string[];
+  capabilityMatrix: string;
+  sourceCards: string;
+  license: string;
+  maintainer: string;
+  claims: ClaimContract;
+  submission: SubmissionContract;
+}
+
+function assertNotSubmitted(path: string, status: string, submission: SubmissionContract): void {
+  if (status !== 'not_submitted' && status !== 'not_started') {
+    failures.push(`${path} must remain not_submitted or not_started.`);
+  }
+  if (submission.allowed !== false) {
+    failures.push(`${path} must block external submission/publication.`);
+  }
+  if (!submission.reason || !/gate|blocked|review|evidence/i.test(submission.reason)) {
+    failures.push(
+      `${path} submission.reason must explain the blocking gate or evidence requirement.`
+    );
+  }
+}
+
+function assertClaims(path: string, claims: ClaimContract): void {
+  if (!/stable/i.test(claims.nz)) {
+    failures.push(`${path} must describe NZ as stable.`);
+  }
+  if (!/(prerelease|planned|unsupported)/i.test(claims.australia)) {
+    failures.push(
+      `${path} must describe Australian support as prerelease, planned, or unsupported.`
+    );
+  }
+  if (
+    /stable Australian|Australian stable|production-ready Australian/i.test(JSON.stringify(claims))
+  ) {
+    failures.push(`${path} must not claim stable Australian support.`);
+  }
+}
+
+const registryDir = 'integrations/mcp/registry-metadata';
+const expectedRegistries = ['smithery', 'mcp-so', 'mcp-market', 'mcp-store', 'pulsemcp', 'glama'];
+for (const name of expectedRegistries) {
+  const path = join(registryDir, `${name}.json`).replaceAll('\\', '/');
+  const metadata = readJson<RegistryMetadata>(path);
+  if (!metadata) continue;
+  assertNotSubmitted(path, metadata.status, metadata.submission);
+  assertClaims(path, metadata.claims);
+  if (metadata.packageName !== 'nz-legislation-tool')
+    failures.push(`${path} packageName must be nz-legislation-tool.`);
+  if (metadata.command !== 'npx') failures.push(`${path} command must be npx.`);
+  if (metadata.args.join(' ') !== '-y --package nz-legislation-tool nzlegislation-mcp') {
+    failures.push(`${path} args must execute nzlegislation-mcp via nz-legislation-tool.`);
+  }
+  if (!metadata.env.includes('NZ_LEGISLATION_API_KEY'))
+    failures.push(`${path} must list NZ_LEGISLATION_API_KEY.`);
+  if (metadata.capabilityMatrix !== 'docs/capabilities.md')
+    failures.push(`${path} must link docs/capabilities.md.`);
+  if (metadata.sourceCards !== 'docs/maintainers/provider-source-cards.md')
+    failures.push(`${path} must link provider source cards.`);
+  if (metadata.license !== 'Apache-2.0') failures.push(`${path} license must be Apache-2.0.`);
+}
+
+const registryFiles = existsSync(registryDir)
+  ? readdirSync(registryDir).filter(file => file.endsWith('.json'))
+  : [];
+if (registryFiles.length !== expectedRegistries.length) {
+  failures.push(
+    `${registryDir} must contain exactly ${expectedRegistries.length} registry metadata files.`
+  );
+}
+
+const vscode = readJson<{
+  status: string;
+  submission: SubmissionContract;
+  packageNames: Record<string, string>;
+  commands: Array<{ id: string; title: string; runtime: string }>;
+  activationEvents: string[];
+  permissions: string[];
+  apiKeyHandling: string;
+  claims: ClaimContract;
+}>('integrations/vscode/extension-contract.json');
+if (vscode) {
+  assertNotSubmitted(
+    'integrations/vscode/extension-contract.json',
+    vscode.status,
+    vscode.submission
+  );
+  assertClaims('integrations/vscode/extension-contract.json', vscode.claims);
+  if (!vscode.permissions.includes('secretStorage'))
+    failures.push('VS Code contract must require secretStorage.');
+  if (!/SecretStorage/.test(vscode.apiKeyHandling))
+    failures.push('VS Code contract must describe SecretStorage API key handling.');
+  if (!vscode.commands.some(command => command.runtime === 'nzlegislation'))
+    failures.push('VS Code contract must map at least one command to nzlegislation.');
+}
+
+const container = readJson<{
+  status: string;
+  submission: SubmissionContract;
+  image: string;
+  entrypoints: string[];
+  sbom: string;
+  provenance: string;
+  claims: ClaimContract;
+}>('distribution/container/container-contract.json');
+if (container) {
+  assertNotSubmitted(
+    'distribution/container/container-contract.json',
+    container.status,
+    container.submission
+  );
+  assertClaims('distribution/container/container-contract.json', container.claims);
+  for (const bin of ['nzlegislation', 'nzlegislation-mcp']) {
+    if (!container.entrypoints.includes(bin))
+      failures.push(`Container contract must include entrypoint ${bin}.`);
+  }
+  if (!/required/i.test(container.sbom) || !/required/i.test(container.provenance)) {
+    failures.push('Container contract must require SBOM and provenance before publication.');
+  }
+}
+
+const homebrew = readJson<{
+  status: string;
+  submission: SubmissionContract;
+  formulaName: string;
+  installCommand: string;
+  binaries: string[];
+  checksumSource: string;
+  claims: ClaimContract;
+}>('distribution/homebrew/formula-contract.json');
+if (homebrew) {
+  assertNotSubmitted(
+    'distribution/homebrew/formula-contract.json',
+    homebrew.status,
+    homebrew.submission
+  );
+  assertClaims('distribution/homebrew/formula-contract.json', homebrew.claims);
+  if (homebrew.formulaName !== 'nz-legislation-tool')
+    failures.push('Homebrew formulaName must be nz-legislation-tool.');
+  for (const bin of [
+    'nzlegislation',
+    'nzlegislation-mcp',
+    'anzlegislation',
+    'anzlegislation-mcp',
+  ]) {
+    if (!homebrew.binaries.includes(bin))
+      failures.push(`Homebrew contract must include binary ${bin}.`);
+  }
+  if (!/brew install/.test(homebrew.installCommand))
+    failures.push('Homebrew contract must include a brew install command.');
+}
+
+for (const workflow of [
+  '.github/workflows/ci.yml',
+  '.github/workflows/release-stable.yml',
+  '.github/workflows/release-next.yml',
+  '.github/workflows/publish-github-packages.yml',
+]) {
+  if (!read(workflow).includes('pnpm gate:channel-readiness')) {
+    failures.push(`${workflow} must run pnpm gate:channel-readiness.`);
+  }
+}
+
+const packageJson = JSON.parse(read('package.json')) as { scripts?: Record<string, string> };
+if (packageJson.scripts?.['gate:channel-readiness'] !== 'tsx scripts/check-channel-readiness.ts') {
+  failures.push(
+    'package.json must define gate:channel-readiness as tsx scripts/check-channel-readiness.ts'
+  );
+}
+
+if (failures.length > 0) {
+  console.error('Channel readiness gate failed:');
+  for (const failure of failures) console.error(`- ${failure}`);
+  process.exit(1);
+}
+
+console.log(
+  'Channel readiness gate passed: registry, assistant/IDE, container, and Homebrew contracts are local-only and guarded.'
+);

--- a/scripts/check-manifest-docs-drift.ts
+++ b/scripts/check-manifest-docs-drift.ts
@@ -92,6 +92,28 @@ for (const capability of capabilities) {
   }
 }
 
+const runtimeDocs = read('docs/provider-runtime.md');
+const sourceCardDocs = read('docs/maintainers/provider-source-cards.md');
+const capabilitiesDocs = read('docs/capabilities.md');
+
+for (const [path, content] of [
+  ['docs/provider-runtime.md', runtimeDocs],
+  ['docs/maintainers/provider-source-cards.md', sourceCardDocs],
+  ['docs/capabilities.md', capabilitiesDocs],
+] as const) {
+  if (!/Australian Commonwealth/i.test(content) || !/prerelease/i.test(content)) {
+    failures.push(path + ' must describe Australian Commonwealth as prerelease.');
+  }
+  if (
+    !/(citation|single-version).{0,80}unsupported/i.test(content) &&
+    !/unsupported.{0,80}(citation|single-version)/i.test(content)
+  ) {
+    failures.push(
+      path + ' must record Commonwealth citation and single-version support as unsupported.'
+    );
+  }
+}
+
 const forbiddenClaimPatterns = [
   /Australian support is stable/i,
   /stable Australian support/i,

--- a/scripts/check-security-provenance.ts
+++ b/scripts/check-security-provenance.ts
@@ -64,12 +64,16 @@ requireIncludes(
 
 const releaseGateCommands = [
   'pnpm gate:no-placeholder-legal-data',
+  'pnpm gate:provider-capability-manifest',
+  'pnpm gate:provider-aware-mcp-export',
+  'pnpm gate:package-metadata',
   'pnpm gate:conductor-requirements',
   'pnpm gate:manifest-docs',
+  'pnpm gate:website-docs',
   'pnpm gate:install-snippets',
+  'pnpm gate:channel-readiness',
   'pnpm gate:security-provenance',
   'pnpm gate:release-notes',
-  'pnpm gate:package-metadata',
   'pnpm typecheck',
   'pnpm test:run',
   'pnpm build',
@@ -89,10 +93,16 @@ for (const workflow of [
 
 requireIncludes('.github/workflows/publish-github-packages.yml', [
   'packages: write',
-  'pnpm gate:security-provenance',
+  'pnpm gate:no-placeholder-legal-data',
+  'pnpm gate:provider-capability-manifest',
+  'pnpm gate:provider-aware-mcp-export',
   'pnpm gate:package-metadata',
-  'pnpm gate:install-snippets',
   'pnpm gate:manifest-docs',
+  'pnpm gate:website-docs',
+  'pnpm gate:install-snippets',
+  'pnpm gate:channel-readiness',
+  'pnpm gate:security-provenance',
+  'pnpm gate:release-notes',
   'pnpm run build',
 ]);
 

--- a/scripts/check-website-docs.ts
+++ b/scripts/check-website-docs.ts
@@ -1,0 +1,172 @@
+import { existsSync, readFileSync } from 'node:fs';
+
+const read = (path: string): string => readFileSync(path, 'utf8');
+const normalize = (value: string): string => value.replace(/\s+/g, ' ').trim();
+const failures: string[] = [];
+
+function requireFile(path: string): void {
+  if (!existsSync(path)) {
+    failures.push(`Missing website/docs file: ${path}`);
+  }
+}
+
+function requireIncludes(path: string, needles: string[]): void {
+  requireFile(path);
+  if (!existsSync(path)) return;
+  const content = normalize(read(path));
+  for (const needle of needles) {
+    if (!content.includes(normalize(needle))) {
+      failures.push(`${path} is missing required website/docs text: ${needle}`);
+    }
+  }
+}
+
+function rejectPattern(path: string, pattern: RegExp, reason: string): void {
+  if (existsSync(path) && pattern.test(read(path))) {
+    failures.push(`${path} contains forbidden website/docs language: ${reason}`);
+  }
+}
+
+const requiredDocs = [
+  'README.md',
+  'llms.txt',
+  'docs/capabilities.md',
+  'docs/provider-runtime.md',
+  'docs/documentation-site-config.md',
+  'docs/documentation-site-setup.md',
+  'docs/maintainers/australian-source-inventory.md',
+  'docs/maintainers/distribution-submission-map.md',
+  'docs/maintainers/install-snippet-verification.md',
+  'docs/maintainers/package-metadata-review.md',
+  'docs/maintainers/provider-source-cards.md',
+  'docs/maintainers/release-notes-anz-readiness-draft.md',
+  'docs/maintainers/security-and-submission-gates-v9.md',
+  'integrations/README.md',
+  'integrations/mcp/example-configs.md',
+];
+
+for (const path of requiredDocs) requireFile(path);
+
+requireIncludes('llms.txt', [
+  'ANZ Legislation',
+  'official-source-first legislation research',
+  'Australian support is prerelease or planned',
+  'docs/capabilities.md',
+  'docs/provider-runtime.md',
+  'docs/maintainers/provider-source-cards.md',
+  'docs/maintainers/distribution-submission-map.md',
+]);
+
+requireIncludes('docs/capabilities.md', [
+  '| New Zealand | `legislation-govt-nz` | Stable | Supported, source-backed',
+  '| Australian Commonwealth | `federal-register-of-legislation` | Prerelease | Supported, source-backed',
+  '| New South Wales | `nsw-legislation` | Planned | Unsupported',
+  '| Northern Territory | `northern-territory-legislation` | Planned | Unsupported',
+  'Commonwealth citation and single-version support: unsupported.',
+  'Do not use this matrix to describe Australia as stable.',
+]);
+
+requireIncludes('README.md', [
+  'npm install -g nz-legislation-tool',
+  'nzlegislation search --query "health act"',
+  'nzlegislation-mcp',
+  'npx -y --package nz-legislation-tool nzlegislation search --query "health"',
+]);
+
+requireIncludes('docs/provider-runtime.md', [
+  'Provider Runtime',
+  'New Zealand is the stable runtime-supported provider',
+  'Australian Commonwealth is source-backed prerelease for search, get-work, versions, export, and MCP paths',
+  'citation and single-version retrieval remain unsupported',
+]);
+
+requireIncludes('docs/maintainers/provider-source-cards.md', [
+  'Australian Commonwealth may include Federal Register of Legislation source metadata and is runtime-supported for source-backed prerelease search',
+  'Australian Commonwealth citation and single-version retrieval remain unsupported',
+  'Australian Commonwealth citation and single-version support: unsupported.',
+  'Do not use source cards to bypass unsupported-provider errors or imply that Australia is stable.',
+]);
+
+requireIncludes('docs/maintainers/australian-source-inventory.md', [
+  'Runtime status must match the provider capability manifest',
+  '| Australian Commonwealth',
+  '| Queensland',
+  '| New South Wales',
+  '| Northern Territory',
+  'Prerelease',
+  'Planned',
+]);
+
+requireIncludes('docs/maintainers/distribution-submission-map.md', [
+  'Package and listing metadata must describe the current NZ runtime.',
+  'Do not claim Australian runtime support until the provider gates pass.',
+  '| Website/docs',
+  '| MCP generic',
+  '| Docker/GHCR',
+  '| Homebrew',
+]);
+
+requireIncludes('docs/maintainers/install-snippet-verification.md', [
+  '`npm install -g nz-legislation-tool`',
+  '`npx -y --package nz-legislation-tool nzlegislation --help`',
+  '`npx -y --package nz-legislation-tool nzlegislation-mcp`',
+]);
+
+requireIncludes('docs/maintainers/package-metadata-review.md', [
+  'Status: preparation only; blocked for external publication until all release/submission gates pass.',
+  '`nz-legislation-tool` remains the npm package name.',
+  'Australian support remains prerelease, planned, or unsupported',
+]);
+
+requireIncludes('integrations/README.md', [
+  'Integrations',
+  'MCP',
+  'Claude',
+  'Codex',
+  'GitHub Copilot',
+]);
+requireIncludes('integrations/mcp/example-configs.md', [
+  '"command": "npx"',
+  '"args": ["-y", "--package", "nz-legislation-tool", "nzlegislation-mcp"]',
+]);
+
+for (const workflow of [
+  '.github/workflows/ci.yml',
+  '.github/workflows/release-stable.yml',
+  '.github/workflows/release-next.yml',
+  '.github/workflows/publish-github-packages.yml',
+]) {
+  requireIncludes(workflow, ['pnpm gate:website-docs']);
+}
+
+const packageJson = JSON.parse(read('package.json')) as { scripts?: Record<string, string> };
+if (packageJson.scripts?.['gate:website-docs'] !== 'tsx scripts/check-website-docs.ts') {
+  failures.push('package.json must define gate:website-docs as tsx scripts/check-website-docs.ts');
+}
+
+const prematureClaims = [
+  {
+    pattern: /\bAustralian\s+(?:runtime\s+)?support\s+(?:is\s+)?stable\b/i,
+    reason: 'Australian support must not be described as stable in website/docs copy.',
+  },
+  {
+    pattern: /\bstable\s+Australian\s+(?:runtime\s+)?support\b/i,
+    reason: 'Australian support must remain prerelease or planned until provider gates pass.',
+  },
+  {
+    pattern: /\bproduction-ready\s+Australian\s+(?:runtime\s+)?support\b/i,
+    reason: 'Australian support is not production-ready.',
+  },
+];
+
+for (const path of requiredDocs) {
+  for (const { pattern, reason } of prematureClaims) rejectPattern(path, pattern, reason);
+}
+
+if (failures.length > 0) {
+  console.error('Website/docs gate failed:');
+  for (const failure of failures) console.error(`- ${failure}`);
+  process.exit(1);
+}
+
+console.log('Website/docs gate passed: docs and website control files match release posture.');

--- a/src/client.ts
+++ b/src/client.ts
@@ -27,6 +27,7 @@ import {
   createCommonwealthProviderAdapter,
   type CommonwealthProviderAdapter,
 } from './providers/commonwealth.js';
+import { assertRuntimeProviderSupported } from './providers/runtime.js';
 import { logger } from './utils/logger.js';
 
 /**
@@ -412,7 +413,10 @@ export async function searchWorks(params: {
   offset?: number;
   jurisdiction?: JurisdictionCode;
 }): Promise<SearchResults> {
-  if (getJurisdiction(params) === 'au-commonwealth') {
+  const jurisdiction = getJurisdiction(params);
+  assertRuntimeProviderSupported(jurisdiction, 'search');
+
+  if (jurisdiction === 'au-commonwealth') {
     return commonwealthProviderAdapterFactory().searchWorks({
       query: params.query,
       type: params.type as WorkType | undefined,
@@ -422,7 +426,16 @@ export async function searchWorks(params: {
     });
   }
 
-  const cacheKey = generateCacheKey('search', params as Record<string, string>);
+  const cacheKey = generateCacheKey('search', {
+    ...(params.query && { query: params.query }),
+    ...(params.type && { type: params.type }),
+    ...(params.status && { status: params.status }),
+    ...(params.from && { from: params.from }),
+    ...(params.to && { to: params.to }),
+    ...(params.limit && { limit: params.limit.toString() }),
+    ...(params.offset && { offset: params.offset.toString() }),
+    jurisdiction,
+  });
 
   // Try cache first
   const cached = getFromCache<SearchResults>(cacheKey);
@@ -493,11 +506,14 @@ export async function getWork(
   workId: string,
   options: { jurisdiction?: JurisdictionCode } = {}
 ): Promise<Work> {
-  if (getJurisdiction(options) === 'au-commonwealth') {
+  const jurisdiction = getJurisdiction(options);
+  assertRuntimeProviderSupported(jurisdiction, 'getWork');
+
+  if (jurisdiction === 'au-commonwealth') {
     return commonwealthProviderAdapterFactory().getWork(workId);
   }
 
-  const cacheKey = generateCacheKey('work', { id: workId, jurisdiction: getJurisdiction(options) });
+  const cacheKey = generateCacheKey('work', { id: workId, jurisdiction });
 
   // Try cache first
   const cached = getFromCache<Work>(cacheKey);
@@ -598,11 +614,14 @@ export async function getWorkVersions(
   workId: string,
   options: { jurisdiction?: JurisdictionCode } = {}
 ): Promise<Version[]> {
-  if (getJurisdiction(options) === 'au-commonwealth') {
+  const jurisdiction = getJurisdiction(options);
+  assertRuntimeProviderSupported(jurisdiction, 'getVersions');
+
+  if (jurisdiction === 'au-commonwealth') {
     return commonwealthProviderAdapterFactory().getWorkVersions(workId);
   }
 
-  const cacheKey = generateCacheKey('versions', { workId, jurisdiction: getJurisdiction(options) });
+  const cacheKey = generateCacheKey('versions', { workId, jurisdiction });
 
   // Try cache first
   const cached = getFromCache<Version[]>(cacheKey);

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -494,13 +494,22 @@ function registerLegislationResource(server: McpServer): void {
     }
 
     try {
-      const work = await getWork(workId);
+      const jurisdiction: JurisdictionCode = 'nz';
+      const work = await getWork(workId, { jurisdiction });
 
       return {
         contents: [
           {
             uri: uri.href,
-            text: JSON.stringify(work, null, 2),
+            text: JSON.stringify(
+              {
+                jurisdiction,
+                sourceCard: getProviderSourceCard(jurisdiction),
+                work,
+              },
+              null,
+              2
+            ),
             mimeType: 'application/json',
           },
         ],

--- a/tests/client.test.ts
+++ b/tests/client.test.ts
@@ -127,6 +127,29 @@ describe('Client error handling', () => {
     expect(calls).toEqual(['search:Legislation Act', 'get:C2004A01224', 'versions:C2004A01224']);
   });
 
+  it('blocks planned Australian jurisdictions before the NZ client path', async () => {
+    let nzClientCalled = false;
+
+    setHttpClientFactoryForTesting(() => ({
+      get: () => {
+        nzClientCalled = true;
+        return { json: async () => ({ results: [] }) };
+      },
+    }));
+
+    await expect(searchWorks({ query: 'water', jurisdiction: 'au-nsw' })).rejects.toMatchObject({
+      name: 'ProviderCapabilityError',
+    });
+    await expect(getWork('act/2020/1', { jurisdiction: 'au-nsw' })).rejects.toMatchObject({
+      name: 'ProviderCapabilityError',
+    });
+    await expect(getWorkVersions('act/2020/1', { jurisdiction: 'au-nsw' })).rejects.toMatchObject({
+      name: 'ProviderCapabilityError',
+    });
+
+    expect(nzClientCalled).toBe(false);
+  });
+
   it('should reconstruct a work from the versions endpoint when the direct work endpoint returns 404', async () => {
     setHttpClientFactoryForTesting(() => ({
       get: (url: string) => ({


### PR DESCRIPTION
## Summary
- add first-class release/submission gates for provider capability, provider-aware MCP/export, website/docs, channel readiness, and no-placeholder legal data
- add local-only registry, IDE, Docker/GHCR, and Homebrew contract metadata without publishing or submission
- update provider/runtime docs and Conductor tracks to distinguish NZ stable support from Commonwealth prerelease and planned AU providers
- block planned Australian jurisdictions before the NZ client path and make the MCP resource explicitly NZ-scoped with source-card output

## Validation
- corepack pnpm install --no-frozen-lockfile
- corepack pnpm gate:release-submission
- corepack pnpm typecheck
- corepack pnpm test:run
- corepack pnpm build
- corepack pnpm audit --audit-level moderate
- corepack pnpm exec prettier --check <changed files>

Note: repo-wide corepack pnpm exec prettier --check . still fails on existing formatting debt and malformed .github/labeler.yml; scoped check for this PR's changed files passes.