### PR TITLE
test: enforce cross-language Rust fixture parity

### DIFF
--- a/.changeset/rust-parity-fixture.md
+++ b/.changeset/rust-parity-fixture.md
@@ -1,0 +1,5 @@
+---
+"nz-legislation-tool": patch
+---
+
+Make the Rust migration contract test consume the shared compatibility fixture and validate its locked dependency tree in CI.

--- a/.github/workflows/rust-contract.yml
+++ b/.github/workflows/rust-contract.yml
@@ -30,3 +30,4 @@ jobs:
       - run: cargo fmt --all -- --check
       - run: cargo check --workspace --locked
       - run: cargo test --workspace --locked
+      - run: cargo tree --workspace --locked

--- a/conductor/tracks/anz-rust-migration-readiness/plan.md
+++ b/conductor/tracks/anz-rust-migration-readiness/plan.md
@@ -16,4 +16,6 @@
 - [x] Define release governance required before cutover.
 - [x] Add executable golden fixtures and contract tests.
 - [x] Add a minimal Rust contract workspace behind the parity gates.
+- [x] Consume the shared JSON compatibility fixture from Rust contract tests.
+- [x] Add locked dependency-tree provenance validation to Rust CI.
 - [ ] Run dual-runtime performance and security comparisons.

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -3,5 +3,105 @@
 version = 4
 
 [[package]]
+name = "itoa"
+version = "1.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
+
+[[package]]
 name = "legislation-compatibility-contract"
 version = "0.1.0"
+dependencies = [
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "memchr"
+version = "2.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf8baf1c55e62ffcace7a9f06f4bd9cd3f0c4beb022d3b367256b91b87513d98"
+
+[[package]]
+name = "proc-macro2"
+version = "1.0.106"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8fd00f0bb2e90d81d1044c2b32617f68fcb9fa3bb7640c23e9c748e53fb30934"
+dependencies = [
+ "unicode-ident",
+]
+
+[[package]]
+name = "quote"
+version = "1.0.46"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dfbc457d0c7a0759a614551b11a6409e5951f6c7537be1f1b7682b9ae9230368"
+dependencies = [
+ "proc-macro2",
+]
+
+[[package]]
+name = "serde"
+version = "1.0.228"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a8e94ea7f378bd32cbbd37198a4a91436180c5bb472411e48b5ec2e2124ae9e"
+dependencies = [
+ "serde_core",
+ "serde_derive",
+]
+
+[[package]]
+name = "serde_core"
+version = "1.0.228"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41d385c7d4ca58e59fc732af25c3983b67ac852c1a25000afe1175de458b67ad"
+dependencies = [
+ "serde_derive",
+]
+
+[[package]]
+name = "serde_derive"
+version = "1.0.228"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "serde_json"
+version = "1.0.150"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e8014e44b4736ed0538adeecded0fce2a272f22dc9578a7eb6b2d9993c74cfb9"
+dependencies = [
+ "itoa",
+ "memchr",
+ "serde",
+ "serde_core",
+ "zmij",
+]
+
+[[package]]
+name = "syn"
+version = "2.0.118"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b9ae57f904213ebb649ce6895b8a66c66f0203b9319718f69a5612a065b1422"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
+name = "unicode-ident"
+version = "1.0.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
+
+[[package]]
+name = "zmij"
+version = "1.0.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"

--- a/rust/compatibility-contract/Cargo.toml
+++ b/rust/compatibility-contract/Cargo.toml
@@ -7,3 +7,7 @@ description = "In-repository Rust migration compatibility contract; not a produc
 
 [lib]
 path = "src/lib.rs"
+
+[dev-dependencies]
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"

--- a/rust/compatibility-contract/src/lib.rs
+++ b/rust/compatibility-contract/src/lib.rs
@@ -27,6 +27,7 @@ mod tests {
     use super::*;
 
     #[derive(Deserialize)]
+    #[serde(rename_all = "camelCase")]
     struct Fixture {
         cli_binaries: Vec<String>,
         mcp_binaries: Vec<String>,

--- a/rust/compatibility-contract/src/lib.rs
+++ b/rust/compatibility-contract/src/lib.rs
@@ -22,7 +22,22 @@ pub const PROVIDER_IDENTIFIERS: &[&str] = &["nz", "au-commonwealth", "au-qld"];
 
 #[cfg(test)]
 mod tests {
+    use serde::Deserialize;
+
     use super::*;
+
+    #[derive(Deserialize)]
+    struct Fixture {
+        cli_binaries: Vec<String>,
+        mcp_binaries: Vec<String>,
+        commands: Vec<String>,
+        provider_identifiers: Vec<String>,
+    }
+
+    const FIXTURE: &str = include_str!(concat!(
+        env!("CARGO_MANIFEST_DIR"),
+        "/../../tests/fixtures/rust/cli-contracts.json"
+    ));
 
     #[test]
     fn preserves_compatibility_aliases() {
@@ -37,5 +52,14 @@ mod tests {
     fn preserves_non_empty_command_and_provider_contracts() {
         assert!(!COMMANDS.is_empty());
         assert_eq!(PROVIDER_IDENTIFIERS, &["nz", "au-commonwealth", "au-qld"]);
+    }
+
+    #[test]
+    fn matches_the_shared_json_fixture() {
+        let fixture: Fixture = serde_json::from_str(FIXTURE).expect("valid compatibility fixture");
+        assert_eq!(fixture.cli_binaries, CLI_BINARIES);
+        assert_eq!(fixture.mcp_binaries, MCP_BINARIES);
+        assert_eq!(fixture.commands, COMMANDS);
+        assert_eq!(fixture.provider_identifiers, PROVIDER_IDENTIFIERS);
     }
 }


### PR DESCRIPTION
Make the staged Rust contract crate consume the shared JSON compatibility fixture directly, and add locked dependency-tree provenance validation to Rust CI.