### PR TITLE
feat: add first gated Rust contract component

### DIFF
--- a/.changeset/rust-contract-validation.md
+++ b/.changeset/rust-contract-validation.md
@@ -1,0 +1,5 @@
+---
+"nz-legislation-tool": patch
+---
+
+Implement the first gated Rust contract-validation component for compatibility aliases, commands, and provider identifiers.

--- a/conductor/tracks/anz-rust-migration-readiness/plan.md
+++ b/conductor/tracks/anz-rust-migration-readiness/plan.md
@@ -18,4 +18,5 @@
 - [x] Add a minimal Rust contract workspace behind the parity gates.
 - [x] Consume the shared JSON compatibility fixture from Rust contract tests.
 - [x] Add locked dependency-tree provenance validation to Rust CI.
+- [x] Implement the first non-publishing Rust runtime component for contract validation.
 - [ ] Run dual-runtime performance and security comparisons.

--- a/rust/compatibility-contract/src/lib.rs
+++ b/rust/compatibility-contract/src/lib.rs
@@ -1,8 +1,8 @@
 //! Language-neutral compatibility constants for the staged Rust migration.
 //!
-//! This crate deliberately contains no CLI, MCP server, provider, or legal-data
-//! runtime. It is a compile-and-test gate that makes the migration contract
-//! executable before implementation work begins.
+//! This crate contains only language-neutral validation, not a CLI, MCP server,
+//! provider, or legal-data runtime. It is the first executable component of the
+//! staged migration and remains non-publishing until parity gates pass.
 
 pub const CLI_BINARIES: &[&str] = &["nzlegislation", "anzlegislation", "legislation"];
 pub const MCP_BINARIES: &[&str] = &["nzlegislation-mcp", "anzlegislation-mcp", "legislation-mcp"];
@@ -19,6 +19,30 @@ pub const COMMANDS: &[&str] = &[
     "stream",
 ];
 pub const PROVIDER_IDENTIFIERS: &[&str] = &["nz", "au-commonwealth", "au-qld"];
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum BinaryKind {
+    Cli,
+    Mcp,
+}
+
+pub fn classify_binary(name: &str) -> Option<BinaryKind> {
+    if CLI_BINARIES.contains(&name) {
+        Some(BinaryKind::Cli)
+    } else if MCP_BINARIES.contains(&name) {
+        Some(BinaryKind::Mcp)
+    } else {
+        None
+    }
+}
+
+pub fn is_supported_command(command: &str) -> bool {
+    COMMANDS.contains(&command)
+}
+
+pub fn is_supported_provider(provider: &str) -> bool {
+    PROVIDER_IDENTIFIERS.contains(&provider)
+}
 
 #[cfg(test)]
 mod tests {
@@ -62,5 +86,16 @@ mod tests {
         assert_eq!(fixture.mcp_binaries, MCP_BINARIES);
         assert_eq!(fixture.commands, COMMANDS);
         assert_eq!(fixture.provider_identifiers, PROVIDER_IDENTIFIERS);
+    }
+
+    #[test]
+    fn validates_binary_command_and_provider_contracts() {
+        assert_eq!(classify_binary("legislation"), Some(BinaryKind::Cli));
+        assert_eq!(classify_binary("legislation-mcp"), Some(BinaryKind::Mcp));
+        assert_eq!(classify_binary("unknown"), None);
+        assert!(is_supported_command("search"));
+        assert!(!is_supported_command("unknown"));
+        assert!(is_supported_provider("au-commonwealth"));
+        assert!(!is_supported_provider("au-nsw"));
     }
 }


### PR DESCRIPTION
Add executable Rust validation for compatibility binaries, commands, and provider identifiers. This remains a non-publishing library component behind the existing parity and release gates.