### PR TITLE
test: add MCP Rust parity fixture

### DIFF
--- a/.changeset/rust-mcp-fixture.md
+++ b/.changeset/rust-mcp-fixture.md
@@ -1,0 +1,5 @@
+---
+'nz-legislation': patch
+---
+
+Add a shared MCP tool and provenance contract fixture for the staged Rust migration.

--- a/conductor/tracks/anz-rust-migration-readiness/plan.md
+++ b/conductor/tracks/anz-rust-migration-readiness/plan.md
@@ -22,4 +22,5 @@
 - [x] Implement provider capability and structured unsupported-capability contracts.
 - [x] Implement gated Rust CLI command and output-format contract parsing.
 - [x] Implement gated Rust MCP request/response and provenance contracts.
+- [x] Add shared MCP tool and provenance fixture parity tests against the TypeScript server.
 - [ ] Run dual-runtime performance and security comparisons.

--- a/rust/compatibility-contract/src/lib.rs
+++ b/rust/compatibility-contract/src/lib.rs
@@ -20,11 +20,13 @@ pub const COMMANDS: &[&str] = &[
 ];
 pub const PROVIDER_IDENTIFIERS: &[&str] = &["nz", "au-commonwealth", "au-qld"];
 pub const MCP_TOOLS: &[&str] = &[
-    "search",
-    "get_work",
-    "get_versions",
-    "export",
-    "capabilities",
+    "search_legislation",
+    "get_legislation",
+    "get_legislation_versions",
+    "generate_citation",
+    "export_legislation",
+    "get_capabilities",
+    "get_config",
 ];
 
 use serde::{Deserialize, Serialize};
@@ -242,10 +244,47 @@ mod tests {
         provider_identifiers: Vec<String>,
     }
 
+    #[derive(Deserialize)]
+    struct McpFixture {
+        tools: Vec<String>,
+        response_fields: Vec<String>,
+        provenance_fields: Vec<String>,
+    }
+
     const FIXTURE: &str = include_str!(concat!(
         env!("CARGO_MANIFEST_DIR"),
         "/../../tests/fixtures/rust/cli-contracts.json"
     ));
+
+    const MCP_FIXTURE: &str = include_str!(concat!(
+        env!("CARGO_MANIFEST_DIR"),
+        "/../../tests/fixtures/rust/mcp-contracts.json"
+    ));
+
+    #[test]
+    fn preserves_mcp_tool_and_provenance_contract() {
+        let fixture: McpFixture = serde_json::from_str(MCP_FIXTURE).expect("valid MCP fixture");
+        assert_eq!(fixture.tools, MCP_TOOLS);
+        assert_eq!(
+            fixture.response_fields,
+            [
+                "tool",
+                "jurisdiction",
+                "release_gate",
+                "submission_gate",
+                "provenance"
+            ]
+        );
+        assert_eq!(
+            fixture.provenance_fields,
+            [
+                "sourceAuthority",
+                "sourceUrl",
+                "retrievedAt",
+                "sourceBacked"
+            ]
+        );
+    }
 
     #[test]
     fn preserves_compatibility_aliases() {

--- a/rust/compatibility-contract/src/lib.rs
+++ b/rust/compatibility-contract/src/lib.rs
@@ -385,7 +385,7 @@ mod tests {
     #[test]
     fn validates_mcp_requests_and_round_trips_provenance_response() {
         let request = McpRequest {
-            tool: "search".to_owned(),
+            tool: "search_legislation".to_owned(),
             jurisdiction: "nz".to_owned(),
         };
         assert!(validate_mcp_request(&request).is_ok());

--- a/tests/fixtures/rust/mcp-contracts.json
+++ b/tests/fixtures/rust/mcp-contracts.json
@@ -1,0 +1,24 @@
+{
+  "tools": [
+    "search_legislation",
+    "get_legislation",
+    "get_legislation_versions",
+    "generate_citation",
+    "export_legislation",
+    "get_capabilities",
+    "get_config"
+  ],
+  "response_fields": [
+    "tool",
+    "jurisdiction",
+    "release_gate",
+    "submission_gate",
+    "provenance"
+  ],
+  "provenance_fields": [
+    "sourceAuthority",
+    "sourceUrl",
+    "retrievedAt",
+    "sourceBacked"
+  ]
+}

--- a/tests/fixtures/rust/mcp-contracts.json
+++ b/tests/fixtures/rust/mcp-contracts.json
@@ -8,17 +8,6 @@
     "get_capabilities",
     "get_config"
   ],
-  "response_fields": [
-    "tool",
-    "jurisdiction",
-    "release_gate",
-    "submission_gate",
-    "provenance"
-  ],
-  "provenance_fields": [
-    "sourceAuthority",
-    "sourceUrl",
-    "retrievedAt",
-    "sourceBacked"
-  ]
+  "response_fields": ["tool", "jurisdiction", "release_gate", "submission_gate", "provenance"],
+  "provenance_fields": ["sourceAuthority", "sourceUrl", "retrievedAt", "sourceBacked"]
 }

--- a/tests/rust-migration-contract.test.ts
+++ b/tests/rust-migration-contract.test.ts
@@ -15,10 +15,20 @@ type RustContract = {
   providerIdentifiers: string[];
 };
 
+type McpContract = {
+  tools: string[];
+  response_fields: string[];
+  provenance_fields: string[];
+};
+
 const packageJson = JSON.parse(readFileSync('package.json', 'utf8')) as PackageJson;
 const contract = JSON.parse(
   readFileSync('tests/fixtures/rust/cli-contracts.json', 'utf8')
 ) as RustContract;
+const mcpContract = JSON.parse(
+  readFileSync('tests/fixtures/rust/mcp-contracts.json', 'utf8')
+) as McpContract;
+const mcpServerSource = readFileSync('src/mcp/server.ts', 'utf8');
 
 describe('Rust migration compatibility contract', () => {
   it('preserves package and executable identities', () => {
@@ -34,5 +44,19 @@ describe('Rust migration compatibility contract', () => {
   it('keeps the command and provider contract inventory non-empty', () => {
     expect(contract.commands.length).toBeGreaterThan(0);
     expect(contract.providerIdentifiers).toEqual(['nz', 'au-commonwealth', 'au-qld']);
+  });
+
+  it('keeps the MCP tool inventory aligned with the TypeScript server', () => {
+    const registeredTools = [...mcpServerSource.matchAll(/server\.tool\(\s*'([^']+)'/g)].map(
+      match => match[1]
+    );
+    expect(registeredTools).toEqual(mcpContract.tools);
+    expect(mcpContract.response_fields).toContain('provenance');
+    expect(mcpContract.provenance_fields).toEqual([
+      'sourceAuthority',
+      'sourceUrl',
+      'retrievedAt',
+      'sourceBacked',
+    ]);
   });
 });


### PR DESCRIPTION
## Summary\n- add shared MCP tool/provenance fixture\n- assert Rust contract and TypeScript server inventory stay aligned\n- record Conductor parity task completion\n\n## Validation\n- cargo fmt --manifest-path rust/Cargo.toml --all -- --check\n- pnpm exec vitest run tests/rust-migration-contract.test.ts\n- Rust cargo check is delegated to GitHub Actions because local MSVC link.exe is unavailable