### PR TITLE
feat: add Rust contract CLI runtime

### DIFF
--- a/.changeset/rust-contract-cli.md
+++ b/.changeset/rust-contract-cli.md
@@ -1,0 +1,5 @@
+---
+'nz-legislation': patch
+---
+
+Add a non-publishing Rust contract binary for executable CLI command and output-format parity.

--- a/conductor/tracks/anz-rust-migration-readiness/plan.md
+++ b/conductor/tracks/anz-rust-migration-readiness/plan.md
@@ -23,4 +23,5 @@
 - [x] Implement gated Rust CLI command and output-format contract parsing.
 - [x] Implement gated Rust MCP request/response and provenance contracts.
 - [x] Add shared MCP tool and provenance fixture parity tests against the TypeScript server.
+- [x] Add a non-publishing Rust CLI contract binary for executable command/output parity.
 - [x] Establish a traceable dual-runtime performance/security comparison harness and explicit no-cutover gate; full Rust runtime comparison remains pending until a Rust runtime exists.

--- a/docs/maintainers/rust-migration-compatibility.md
+++ b/docs/maintainers/rust-migration-compatibility.md
@@ -38,3 +38,7 @@ Before Rust becomes a release candidate, the migration must provide:
   release checks pass in CI.
 - The TypeScript implementation remains the fallback until a documented,
   reversible cutover decision is approved.
+
+The Rust workspace includes a non-publishing `legislation-contract` binary. It
+validates command and output-format compatibility only; it does not fetch legal
+data, expose MCP, or authorize runtime cutover.

--- a/rust/compatibility-contract/Cargo.toml
+++ b/rust/compatibility-contract/Cargo.toml
@@ -10,6 +10,6 @@ path = "src/lib.rs"
 
 [dependencies]
 serde = { version = "1", features = ["derive"] }
+serde_json = "1"
 
 [dev-dependencies]
-serde_json = "1"

--- a/rust/compatibility-contract/src/bin/legislation-contract.rs
+++ b/rust/compatibility-contract/src/bin/legislation-contract.rs
@@ -1,0 +1,32 @@
+use legislation_compatibility_contract::parse_command_args;
+use serde::Serialize;
+
+#[derive(Serialize)]
+struct ContractOutput {
+    runtime: &'static str,
+    command: String,
+    format: &'static str,
+    jurisdiction: Option<String>,
+}
+
+fn main() {
+    let request = parse_command_args(std::env::args().skip(1)).unwrap_or_else(|error| {
+        eprintln!("invalid compatibility command: {error:?}");
+        std::process::exit(2);
+    });
+    let format = match request.format {
+        legislation_compatibility_contract::OutputFormat::Table => "table",
+        legislation_compatibility_contract::OutputFormat::Json => "json",
+        legislation_compatibility_contract::OutputFormat::Csv => "csv",
+    };
+    let output = ContractOutput {
+        runtime: "rust-compatibility-contract",
+        command: request.command,
+        format,
+        jurisdiction: request.jurisdiction,
+    };
+    println!(
+        "{}",
+        serde_json::to_string(&output).expect("contract output serializes")
+    );
+}

--- a/rust/compatibility-contract/src/lib.rs
+++ b/rust/compatibility-contract/src/lib.rs
@@ -264,6 +264,7 @@ mod tests {
     #[serde(rename_all = "camelCase")]
     struct RuntimeEntry {
         available: bool,
+        contract_runtime_available: bool,
         security_checks: Vec<String>,
         performance_evidence: Option<String>,
     }
@@ -293,6 +294,7 @@ mod tests {
             Some("benchmarks/performance.ts")
         );
         assert!(!fixture.rust_runtime.available);
+        assert!(fixture.rust_runtime.contract_runtime_available);
         assert!(fixture.rust_runtime.performance_evidence.is_none());
         assert!(!fixture.cutover_allowed);
         assert!(fixture.reason.contains("not yet available"));

--- a/rust/compatibility-contract/src/lib.rs
+++ b/rust/compatibility-contract/src/lib.rs
@@ -264,7 +264,6 @@ mod tests {
     #[serde(rename_all = "camelCase")]
     struct RuntimeEntry {
         available: bool,
-        contract_runtime_available: bool,
         security_checks: Vec<String>,
         performance_evidence: Option<String>,
     }
@@ -294,7 +293,6 @@ mod tests {
             Some("benchmarks/performance.ts")
         );
         assert!(!fixture.rust_runtime.available);
-        assert!(fixture.rust_runtime.contract_runtime_available);
         assert!(fixture.rust_runtime.performance_evidence.is_none());
         assert!(!fixture.cutover_allowed);
         assert!(fixture.reason.contains("not yet available"));

--- a/tests/fixtures/rust/runtime-comparison.json
+++ b/tests/fixtures/rust/runtime-comparison.json
@@ -6,6 +6,7 @@
   },
   "rustRuntime": {
     "available": false,
+    "contractRuntimeAvailable": true,
     "securityChecks": ["cargo-check-locked", "cargo-test-locked", "cargo-tree-locked"],
     "performanceEvidence": null
   },

--- a/tests/rust-runtime-comparison.test.ts
+++ b/tests/rust-runtime-comparison.test.ts
@@ -4,7 +4,12 @@ import { describe, expect, it } from 'vitest';
 
 type RuntimeComparison = {
   typescriptRuntime: { available: boolean; securityChecks: string[]; performanceEvidence: string };
-  rustRuntime: { available: boolean; securityChecks: string[]; performanceEvidence: string | null };
+  rustRuntime: {
+    available: boolean;
+    contractRuntimeAvailable: boolean;
+    securityChecks: string[];
+    performanceEvidence: string | null;
+  };
   cutoverAllowed: boolean;
   reason: string;
 };
@@ -18,6 +23,7 @@ describe('Rust migration runtime comparison gate', () => {
     expect(comparison.typescriptRuntime.available).toBe(true);
     expect(comparison.typescriptRuntime.performanceEvidence).toBe('benchmarks/performance.ts');
     expect(comparison.rustRuntime.available).toBe(false);
+    expect(comparison.rustRuntime.contractRuntimeAvailable).toBe(true);
     expect(comparison.rustRuntime.performanceEvidence).toBeNull();
     expect(comparison.cutoverAllowed).toBe(false);
     expect(comparison.reason).toMatch(/not yet available/);


### PR DESCRIPTION
## Summary\n- add a non-publishing Rust contract CLI binary\n- emit deterministic JSON for command/output-format parity\n- extend comparison evidence to distinguish contract runtime from full legal-data runtime\n- keep full cutover blocked until provider/MCP runtime evidence exists\n\n## Validation\n- cargo fmt check\n- required Rust CI will run cargo check/test/tree locked\n- comparison fixture remains explicit about no cutover