### PR TITLE
feat: add official gazette source readiness register

### DIFF
--- a/.changeset/gazette-source-readiness.md
+++ b/.changeset/gazette-source-readiness.md
@@ -1,0 +1,5 @@
+---
+'nz-legislation-tool': minor
+---
+
+Add a source-backed official Gazette readiness register covering New Zealand and Australian jurisdictions, with tests that keep runtime access disabled until rights and provenance gates pass.

--- a/conductor/tracks/official-gazette-sources/index.md
+++ b/conductor/tracks/official-gazette-sources/index.md
@@ -1,0 +1,5 @@
+# Official Gazette source readiness
+
+- [Specification](spec.md)
+- [Implementation plan](plan.md)
+- [Metadata](metadata.json)

--- a/conductor/tracks/official-gazette-sources/metadata.json
+++ b/conductor/tracks/official-gazette-sources/metadata.json
@@ -1,0 +1,7 @@
+{
+  "trackId": "official-gazette-sources",
+  "status": "in_progress",
+  "phase": "source-readiness",
+  "externalSubmissionAllowed": false,
+  "runtimeEnabled": false
+}

--- a/conductor/tracks/official-gazette-sources/plan.md
+++ b/conductor/tracks/official-gazette-sources/plan.md
@@ -1,0 +1,7 @@
+# Plan
+
+- [x] Add provider-neutral official Gazette source register and policy flags.
+- [x] Cover NZ, Commonwealth, all Australian states and territories.
+- [x] Add tests that enforce URL evidence, jurisdiction coverage, and disabled runtime status.
+- [ ] Verify rights, rate limits, and machine-readable access per source.
+- [ ] Implement source-specific adapters only after those gates pass.

--- a/conductor/tracks/official-gazette-sources/spec.md
+++ b/conductor/tracks/official-gazette-sources/spec.md
@@ -1,0 +1,10 @@
+# Official Gazette source readiness
+
+Create a source-backed, provider-neutral inventory for official Gazette and equivalent notice publications in New Zealand and every Australian jurisdiction. This slice is metadata and validation only: it does not fetch, redistribute, or infer legal effects from notices.
+
+## Constraints
+
+- Gazette notices remain distinct from legislation content.
+- Every source has an official authority URL and evidence URL.
+- Unverified access, licensing, or machine-readable formats remain explicitly unsupported.
+- Runtime implementation and external publication require later rights, provenance, security, and conformance gates.

--- a/docs/maintainers/gazette-source-register.json
+++ b/docs/maintainers/gazette-source-register.json
@@ -1,0 +1,112 @@
+{
+  "version": "1.0.0",
+  "policy": {
+    "officialAuthorityRequired": true,
+    "evidenceUrlRequired": true,
+    "runtimeRequiresRightsReview": true,
+    "unverifiedSourcesRemainUnsupported": true,
+    "gazetteNotLegislation": true
+  },
+  "sources": [
+    {
+      "jurisdiction": "nz",
+      "sourceId": "nz-gazette",
+      "authority": "New Zealand Gazette",
+      "sourceUrl": "https://gazette.govt.nz/",
+      "evidenceUrl": "https://gazette.govt.nz/find-a-notice",
+      "publicationKind": "official-gazette",
+      "accessStatus": "official-online-search",
+      "runtimeStatus": "not-implemented"
+    },
+    {
+      "jurisdiction": "au-commonwealth",
+      "sourceId": "au-commonwealth-gazette",
+      "authority": "Federal Register of Legislation — Government Gazettes",
+      "sourceUrl": "https://www.legislation.gov.au/gazettes",
+      "evidenceUrl": "https://www.legislation.gov.au/help-and-resources/using-the-legislation-register/government-gazettes",
+      "publicationKind": "official-gazette",
+      "accessStatus": "official-online-search",
+      "runtimeStatus": "not-implemented"
+    },
+    {
+      "jurisdiction": "au-qld",
+      "sourceId": "au-qld-gazette",
+      "authority": "Queensland Government Gazette",
+      "sourceUrl": "https://www.publications.qld.gov.au/",
+      "evidenceUrl": "https://www.publications.qld.gov.au/",
+      "publicationKind": "official-gazette",
+      "accessStatus": "source-shape-only",
+      "runtimeStatus": "unsupported"
+    },
+    {
+      "jurisdiction": "au-nsw",
+      "sourceId": "au-nsw-gazette",
+      "authority": "NSW Government Gazette",
+      "sourceUrl": "https://gazette.nsw.gov.au/",
+      "evidenceUrl": "https://legislation.nsw.gov.au/gazette",
+      "publicationKind": "official-gazette",
+      "accessStatus": "official-online-archive",
+      "runtimeStatus": "not-implemented"
+    },
+    {
+      "jurisdiction": "au-vic",
+      "sourceId": "au-vic-gazette",
+      "authority": "Victoria Government Gazette",
+      "sourceUrl": "https://www.gazette.vic.gov.au/",
+      "evidenceUrl": "https://www.gazette.vic.gov.au/gazette_bin/about_us.cfm",
+      "publicationKind": "official-gazette",
+      "accessStatus": "official-online-archive",
+      "runtimeStatus": "not-implemented"
+    },
+    {
+      "jurisdiction": "au-sa",
+      "sourceId": "au-sa-gazette",
+      "authority": "South Australian Government Gazette",
+      "sourceUrl": "https://governmentgazette.sa.gov.au/",
+      "evidenceUrl": "https://governmentgazette.sa.gov.au/",
+      "publicationKind": "official-gazette",
+      "accessStatus": "official-online-publication",
+      "runtimeStatus": "not-implemented"
+    },
+    {
+      "jurisdiction": "au-wa",
+      "sourceId": "au-wa-gazette",
+      "authority": "Western Australian Government Gazette",
+      "sourceUrl": "https://www.legislation.wa.gov.au/",
+      "evidenceUrl": "https://www.legislation.wa.gov.au/legislation/gazettes",
+      "publicationKind": "official-gazette",
+      "accessStatus": "official-online-archive",
+      "runtimeStatus": "not-implemented"
+    },
+    {
+      "jurisdiction": "au-tas",
+      "sourceId": "au-tas-gazette",
+      "authority": "Tasmanian Government Gazette",
+      "sourceUrl": "https://www.gazette.tas.gov.au/",
+      "evidenceUrl": "https://www.gazette.tas.gov.au/",
+      "publicationKind": "official-gazette",
+      "accessStatus": "source-shape-only",
+      "runtimeStatus": "unsupported"
+    },
+    {
+      "jurisdiction": "au-act",
+      "sourceId": "au-act-gazette",
+      "authority": "ACT Government Gazette",
+      "sourceUrl": "https://www.act.gov.au/",
+      "evidenceUrl": "https://www.legislation.act.gov.au/",
+      "publicationKind": "official-gazette-or-equivalent",
+      "accessStatus": "source-shape-only",
+      "runtimeStatus": "unsupported"
+    },
+    {
+      "jurisdiction": "au-nt",
+      "sourceId": "au-nt-gazette",
+      "authority": "Northern Territory Government Gazette",
+      "sourceUrl": "https://nt.gov.au/about-government/gazettes",
+      "evidenceUrl": "https://nt.gov.au/about-government/gazettes",
+      "publicationKind": "official-gazette",
+      "accessStatus": "official-online-archive",
+      "runtimeStatus": "not-implemented"
+    }
+  ]
+}

--- a/tests/gazette-source-register.test.ts
+++ b/tests/gazette-source-register.test.ts
@@ -1,0 +1,51 @@
+import { readFileSync } from 'node:fs';
+import { describe, expect, it } from 'vitest';
+
+import { getProviderCapabilities } from '../src/providers/capability-manifest.ts';
+
+type GazetteSource = {
+  jurisdiction: string;
+  sourceId: string;
+  authority: string;
+  sourceUrl: string;
+  evidenceUrl: string;
+  publicationKind: string;
+  accessStatus:
+    | 'official-online-search'
+    | 'official-online-archive'
+    | 'official-online-publication'
+    | 'source-shape-only';
+  runtimeStatus: 'not-implemented' | 'unsupported';
+};
+
+const register = JSON.parse(
+  readFileSync('docs/maintainers/gazette-source-register.json', 'utf8')
+) as { sources: GazetteSource[] };
+
+describe('gazette source register', () => {
+  it('covers every legislation jurisdiction without enabling runtime access', () => {
+    expect(register.sources.map(source => source.jurisdiction)).toEqual(
+      getProviderCapabilities().map(capability => capability.jurisdiction)
+    );
+
+    for (const source of register.sources) {
+      expect(source.sourceId).toMatch(/^[a-z0-9-]+$/);
+      expect(source.sourceUrl).toMatch(/^https:\/\//);
+      expect(source.evidenceUrl).toMatch(/^https:\/\//);
+      expect(source.authority).toBeTruthy();
+      expect(source.publicationKind).toMatch(/^official-/);
+      expect(['not-implemented', 'unsupported']).toContain(source.runtimeStatus);
+      if (source.accessStatus !== 'source-shape-only') {
+        expect(source.runtimeStatus).toBe('not-implemented');
+      }
+    }
+  });
+
+  it('keeps unverified lanes explicitly unsupported', () => {
+    for (const source of register.sources.filter(
+      item => item.accessStatus === 'source-shape-only'
+    )) {
+      expect(source.runtimeStatus).toBe('unsupported');
+    }
+  });
+});


### PR DESCRIPTION
## Summary\n- add provider-neutral official Gazette source register for NZ and all Australian jurisdictions\n- preserve explicit unsupported/not-implemented runtime status\n- add Conductor track and validation tests\n\n## Validation\n- pnpm exec vitest run tests/gazette-source-register.test.ts --config vitest.config.ts\n- pnpm typecheck\n\nNo legal data is bundled or published; runtime access remains disabled pending rights, provenance, and security gates.