### PR TITLE
test: add deterministic runtime comparison evidence gate

### DIFF
--- a/.changeset/rust-runtime-evidence-gate.md
+++ b/.changeset/rust-runtime-evidence-gate.md
@@ -1,0 +1,5 @@
+---
+'nz-legislation': patch
+---
+
+Add deterministic dual-runtime performance and security evidence gates without benchmarking live legal data.

--- a/conductor/tracks/anz-rust-migration-readiness/plan.md
+++ b/conductor/tracks/anz-rust-migration-readiness/plan.md
@@ -31,3 +31,4 @@
 - [x] Add a source-backed Rust provider capability manifest for the staged provider inventory.
 - [x] Establish a traceable dual-runtime performance/security comparison harness and explicit no-cutover gate; full Rust runtime comparison remains pending until a Rust runtime exists.
 - [x] Add source-backed Commonwealth API request-shape parity fixtures for search, title, and version lookups without fetching or fabricating legal data.
+- [x] Add deterministic dual-runtime performance/security evidence schema and tests; keep cutover blocked until provider-backed Rust parity evidence exists.

--- a/rust/compatibility-contract/src/lib.rs
+++ b/rust/compatibility-contract/src/lib.rs
@@ -611,6 +611,43 @@ mod tests {
         "/../../tests/fixtures/rust/runtime-comparison.json"
     ));
 
+    const RUNTIME_EVIDENCE: &str = include_str!(concat!(
+        env!("CARGO_MANIFEST_DIR"),
+        "/../../tests/fixtures/rust/runtime-comparison-evidence.json"
+    ));
+
+    #[derive(Debug, Deserialize)]
+    #[serde(rename_all = "camelCase")]
+    struct RuntimeEvidence {
+        schema_version: u8,
+        mode: String,
+        live_legal_data: bool,
+        typescript: RuntimeEvidenceSide,
+        rust: RustEvidenceSide,
+        cutover: CutoverEvidence,
+    }
+    #[derive(Debug, Deserialize)]
+    #[serde(rename_all = "camelCase")]
+    struct RuntimeEvidenceSide {
+        status: String,
+        timing_source: Option<String>,
+        security_evidence: Vec<String>,
+    }
+    #[derive(Debug, Deserialize)]
+    #[serde(rename_all = "camelCase")]
+    struct RustEvidenceSide {
+        status: String,
+        timing_source: Option<String>,
+        security_evidence: Vec<String>,
+        blocked_reason: Option<String>,
+    }
+    #[derive(Debug, Deserialize)]
+    #[serde(rename_all = "camelCase")]
+    struct CutoverEvidence {
+        allowed: bool,
+        required_evidence: Vec<String>,
+    }
+
     const COMMONWEALTH_FIXTURE: &str = include_str!(concat!(
         env!("CARGO_MANIFEST_DIR"),
         "/../../tests/fixtures/rust/commonwealth-contracts.json"
@@ -636,6 +673,39 @@ mod tests {
                 "cargo-check-locked".to_owned(),
                 "cargo-test-locked".to_owned(),
                 "cargo-tree-locked".to_owned()
+            ]
+        );
+    }
+
+    #[test]
+    fn enforces_deterministic_dual_runtime_evidence_gate() {
+        let evidence: RuntimeEvidence =
+            serde_json::from_str(RUNTIME_EVIDENCE).expect("valid evidence fixture");
+        assert_eq!(evidence.schema_version, 1);
+        assert_eq!(evidence.mode, "contract-only");
+        assert!(!evidence.live_legal_data);
+        assert_eq!(evidence.typescript.status, "measured");
+        assert_eq!(
+            evidence.typescript.timing_source.as_deref(),
+            Some("benchmarks/performance.ts")
+        );
+        assert!(!evidence.typescript.security_evidence.is_empty());
+        assert_eq!(evidence.rust.status, "blocked");
+        assert!(evidence.rust.timing_source.is_none());
+        assert!(evidence
+            .rust
+            .blocked_reason
+            .as_deref()
+            .is_some_and(|reason| reason.contains("provider-backed Rust runtime")));
+        assert!(!evidence.rust.security_evidence.is_empty());
+        assert!(!evidence.cutover.allowed);
+        assert_eq!(
+            evidence.cutover.required_evidence,
+            vec![
+                "provider-backed-runtime",
+                "same-fixtures",
+                "performance-comparison",
+                "security-comparison"
             ]
         );
     }

--- a/tests/fixtures/rust/runtime-comparison-evidence.json
+++ b/tests/fixtures/rust/runtime-comparison-evidence.json
@@ -1,0 +1,20 @@
+{
+  "schemaVersion": 1,
+  "mode": "contract-only",
+  "liveLegalData": false,
+  "typescript": {
+    "status": "measured",
+    "timingSource": "benchmarks/performance.ts",
+    "securityEvidence": ["dependency-review", "codeql", "security-provenance-gate"]
+  },
+  "rust": {
+    "status": "blocked",
+    "timingSource": null,
+    "securityEvidence": ["cargo-check-locked", "cargo-test-locked", "cargo-tree-locked"],
+    "blockedReason": "A provider-backed Rust runtime is not available; contract timings cannot be treated as runtime parity evidence."
+  },
+  "cutover": {
+    "allowed": false,
+    "requiredEvidence": ["provider-backed-runtime", "same-fixtures", "performance-comparison", "security-comparison"]
+  }
+}

--- a/tests/rust-runtime-comparison-evidence.test.ts
+++ b/tests/rust-runtime-comparison-evidence.test.ts
@@ -1,0 +1,53 @@
+import { readFileSync } from 'node:fs';
+import { describe, expect, it } from 'vitest';
+
+type Evidence = {
+  schemaVersion: number;
+  mode: string;
+  liveLegalData: boolean;
+  typescript: { status: string; timingSource: string | null; securityEvidence: string[] };
+  rust: {
+    status: string;
+    timingSource: string | null;
+    securityEvidence: string[];
+    blockedReason: string | null;
+  };
+  cutover: { allowed: boolean; requiredEvidence: string[] };
+};
+const evidence = JSON.parse(
+  readFileSync('tests/fixtures/rust/runtime-comparison-evidence.json', 'utf8')
+) as Evidence;
+
+describe('dual-runtime comparison evidence gate', () => {
+  it('is deterministic and never benchmarks live legal data', () => {
+    expect(evidence.schemaVersion).toBe(1);
+    expect(evidence.mode).toBe('contract-only');
+    expect(evidence.liveLegalData).toBe(false);
+  });
+  it('blocks cutover until provider runtime parity evidence exists', () => {
+    expect(evidence.typescript.status).toBe('measured');
+    expect(evidence.typescript.timingSource).toBe('benchmarks/performance.ts');
+    expect(evidence.rust.status).toBe('blocked');
+    expect(evidence.rust.timingSource).toBeNull();
+    expect(evidence.rust.blockedReason).toMatch(/provider-backed Rust runtime/);
+    expect(evidence.cutover.allowed).toBe(false);
+    expect(evidence.cutover.requiredEvidence).toEqual([
+      'provider-backed-runtime',
+      'same-fixtures',
+      'performance-comparison',
+      'security-comparison',
+    ]);
+  });
+  it('records security gates for both runtimes', () => {
+    expect(evidence.typescript.securityEvidence).toEqual([
+      'dependency-review',
+      'codeql',
+      'security-provenance-gate',
+    ]);
+    expect(evidence.rust.securityEvidence).toEqual([
+      'cargo-check-locked',
+      'cargo-test-locked',
+      'cargo-tree-locked',
+    ]);
+  });
+});


### PR DESCRIPTION
## Summary\n- add a language-neutral runtime comparison evidence fixture\n- assert deterministic no-live-data and security gate requirements in Rust and TypeScript\n- keep Rust cutover blocked until provider-backed parity evidence exists\n\n## Validation\n- targeted Vitest passes\n- cargo fmt passes (local cargo linking unavailable on this workstation; GitHub Rust CI is required)