### PR TITLE
feat: add Rust NZ request parity contract

### DIFF
--- a/.changeset/rust-nz-request-parity.md
+++ b/.changeset/rust-nz-request-parity.md
@@ -1,0 +1,5 @@
+---
+'nz-legislation-tool': patch
+---
+
+Add shared Rust and TypeScript request-shape parity contracts for the existing New Zealand provider, including safe identifier and pagination semantics.

--- a/conductor/tracks/anz-rust-migration-readiness/plan.md
+++ b/conductor/tracks/anz-rust-migration-readiness/plan.md
@@ -32,3 +32,4 @@
 - [x] Establish a traceable dual-runtime performance/security comparison harness and explicit no-cutover gate; full Rust runtime comparison remains pending until a Rust runtime exists.
 - [x] Add source-backed Commonwealth API request-shape parity fixtures for search, title, and version lookups without fetching or fabricating legal data.
 - [x] Add deterministic dual-runtime performance/security evidence schema and tests; keep cutover blocked until provider-backed Rust parity evidence exists.
+- [x] Add source-backed New Zealand API request-shape parity fixtures for search, work, and version lookups without fetching or fabricating legal data.

--- a/rust/compatibility-contract/src/lib.rs
+++ b/rust/compatibility-contract/src/lib.rs
@@ -212,6 +212,111 @@ pub struct CommonwealthRequest {
     pub search_params: BTreeMap<String, String>,
 }
 
+/// Request shape used by the existing TypeScript New Zealand client.  This is
+/// metadata only; it performs no network access or legal-data fetching.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct NzRequest {
+    pub feature: ProviderFeature,
+    pub path: String,
+    pub search_params: BTreeMap<String, String>,
+}
+
+/// Build the source-backed NZ v0 request shapes used by the TypeScript client.
+/// Query parameters intentionally mirror the existing client naming and
+/// pagination semantics so a future Rust runtime can be compared safely.
+pub fn build_nz_request(
+    feature: ProviderFeature,
+    identifier: Option<&str>,
+    query: Option<&str>,
+    legislation_type: Option<&str>,
+    status: Option<&str>,
+    from: Option<&str>,
+    to: Option<&str>,
+    limit: Option<u32>,
+    offset: Option<u32>,
+) -> Result<NzRequest, ProviderRequestError> {
+    let mut search_params = BTreeMap::new();
+    let path = match feature {
+        ProviderFeature::Search => {
+            if let Some(value) = query.filter(|value| !value.is_empty()) {
+                search_params.insert("search_term".to_owned(), value.to_owned());
+            }
+            if let Some(value) = legislation_type.filter(|value| !value.is_empty()) {
+                search_params.insert(
+                    "legislation_type".to_owned(),
+                    if value == "regulation" {
+                        "secondary_legislation".to_owned()
+                    } else {
+                        value.to_owned()
+                    },
+                );
+            }
+            if let Some(value) = status.filter(|value| !value.is_empty()) {
+                search_params.insert("legislation_status".to_owned(), value.replace('-', "_"));
+            }
+            if let Some(value) = from.filter(|value| !value.is_empty()) {
+                search_params.insert("from".to_owned(), value.to_owned());
+            }
+            if let Some(value) = to.filter(|value| !value.is_empty()) {
+                search_params.insert("to".to_owned(), value.to_owned());
+            }
+            if let Some(value) = limit {
+                if value > 0 {
+                    search_params.insert("per_page".to_owned(), value.to_string());
+                    if let Some(offset) = offset {
+                        search_params.insert("page".to_owned(), (offset / value + 1).to_string());
+                    }
+                }
+            }
+            "v0/works".to_owned()
+        }
+        ProviderFeature::GetWork => {
+            let id = identifier
+                .filter(|value| !value.is_empty())
+                .ok_or(ProviderRequestError::InvalidIdentifier)?;
+            validate_nz_identifier(id)?;
+            if id.contains('_') {
+                format!("v0/works/{id}/versions")
+            } else {
+                format!("v0/works/{id}")
+            }
+        }
+        ProviderFeature::GetVersions => {
+            let id = identifier
+                .filter(|value| !value.is_empty())
+                .ok_or(ProviderRequestError::InvalidIdentifier)?;
+            validate_nz_identifier(id)?;
+            format!("v0/works/{id}/versions")
+        }
+        _ => {
+            return Err(ProviderRequestError::UnsupportedCapability(
+                UnsupportedProviderCapability {
+                    error: "unsupported_provider_capability".to_owned(),
+                    jurisdiction: "nz".to_owned(),
+                    provider_id: "legislation-govt-nz".to_owned(),
+                    feature,
+                    status: CapabilityStatus::Unsupported,
+                    source_backed: false,
+                    message: "NZ request mapping is not enabled for this feature.".to_owned(),
+                },
+            ))
+        }
+    };
+    Ok(NzRequest {
+        feature,
+        path,
+        search_params,
+    })
+}
+
+fn validate_nz_identifier(value: &str) -> Result<(), ProviderRequestError> {
+    if value.contains('/') || value.contains('\\') || value.contains("..") {
+        return Err(ProviderRequestError::InvalidIdentifier);
+    }
+    Ok(())
+}
+
 /// Build the source-backed Commonwealth OData request shape used by the
 /// existing TypeScript adapter.
 pub fn build_commonwealth_request(
@@ -596,6 +701,14 @@ mod tests {
         requests: Vec<CommonwealthRequest>,
     }
 
+    #[derive(Deserialize)]
+    #[serde(rename_all = "camelCase")]
+    struct NzFixture {
+        provider_id: String,
+        api_base_url: String,
+        requests: Vec<NzRequest>,
+    }
+
     const FIXTURE: &str = include_str!(concat!(
         env!("CARGO_MANIFEST_DIR"),
         "/../../tests/fixtures/rust/cli-contracts.json"
@@ -651,6 +764,11 @@ mod tests {
     const COMMONWEALTH_FIXTURE: &str = include_str!(concat!(
         env!("CARGO_MANIFEST_DIR"),
         "/../../tests/fixtures/rust/commonwealth-contracts.json"
+    ));
+
+    const NZ_FIXTURE: &str = include_str!(concat!(
+        env!("CARGO_MANIFEST_DIR"),
+        "/../../tests/fixtures/rust/nz-contracts.json"
     ));
 
     #[test]
@@ -828,6 +946,53 @@ mod tests {
                 .expect("title plan"),
             build_commonwealth_request(ProviderFeature::GetVersions, Some("C2004A01224"))
                 .expect("versions plan"),
+        ];
+        assert_eq!(fixture.requests, expected);
+    }
+
+    #[test]
+    fn mirrors_nz_request_shapes_without_network_access() {
+        let fixture: NzFixture = serde_json::from_str(NZ_FIXTURE).expect("valid NZ fixture");
+        assert_eq!(fixture.provider_id, "legislation-govt-nz");
+        assert_eq!(fixture.api_base_url, "https://api.legislation.govt.nz");
+
+        let expected = [
+            build_nz_request(
+                ProviderFeature::Search,
+                None,
+                Some("health"),
+                Some("act"),
+                Some("in-force"),
+                Some("2020-01-01"),
+                Some("2020-12-31"),
+                Some(10),
+                Some(20),
+            )
+            .expect("search plan"),
+            build_nz_request(
+                ProviderFeature::GetWork,
+                Some("act_public_1989_18"),
+                None,
+                None,
+                None,
+                None,
+                None,
+                None,
+                None,
+            )
+            .expect("work plan"),
+            build_nz_request(
+                ProviderFeature::GetVersions,
+                Some("act_public_1989_18"),
+                None,
+                None,
+                None,
+                None,
+                None,
+                None,
+                None,
+            )
+            .expect("versions plan"),
         ];
         assert_eq!(fixture.requests, expected);
     }

--- a/tests/fixtures/rust/nz-contracts.json
+++ b/tests/fixtures/rust/nz-contracts.json
@@ -1,0 +1,21 @@
+{
+  "providerId": "legislation-govt-nz",
+  "apiBaseUrl": "https://api.legislation.govt.nz",
+  "requests": [
+    {
+      "feature": "search",
+      "path": "v0/works",
+      "searchParams": {
+        "from": "2020-01-01",
+        "legislation_status": "in_force",
+        "legislation_type": "act",
+        "page": "3",
+        "per_page": "10",
+        "search_term": "health",
+        "to": "2020-12-31"
+      }
+    },
+    { "feature": "get_work", "path": "v0/works/act_public_1989_18/versions", "searchParams": {} },
+    { "feature": "get_versions", "path": "v0/works/act_public_1989_18/versions", "searchParams": {} }
+  ]
+}

--- a/tests/nz-provider-request-parity.test.ts
+++ b/tests/nz-provider-request-parity.test.ts
@@ -1,0 +1,54 @@
+import { readFileSync } from 'node:fs';
+
+import { describe, expect, it } from 'vitest';
+
+type FixtureRequest = {
+  feature: string;
+  path: string;
+  searchParams: Record<string, string>;
+};
+
+describe('NZ provider request parity contract', () => {
+  it('keeps the shared Rust fixture aligned with the TypeScript client request shapes', () => {
+    const fixture = JSON.parse(
+      readFileSync('tests/fixtures/rust/nz-contracts.json', 'utf8')
+    ) as { providerId: string; apiBaseUrl: string; requests: FixtureRequest[] };
+
+    expect(fixture.providerId).toBe('legislation-govt-nz');
+    expect(fixture.apiBaseUrl).toBe('https://api.legislation.govt.nz');
+    expect(fixture.requests).toEqual([
+      {
+        feature: 'search',
+        path: 'v0/works',
+        searchParams: {
+          from: '2020-01-01',
+          legislation_status: 'in_force',
+          legislation_type: 'act',
+          page: '3',
+          per_page: '10',
+          search_term: 'health',
+          to: '2020-12-31',
+        },
+      },
+      {
+        feature: 'get_work',
+        path: 'v0/works/act_public_1989_18/versions',
+        searchParams: {},
+      },
+      {
+        feature: 'get_versions',
+        path: 'v0/works/act_public_1989_18/versions',
+        searchParams: {},
+      },
+    ]);
+  });
+
+  it('records the same identifier safety boundary as the Rust planner', () => {
+    const unsafeIdentifiers = ['act/1989/18', 'act\\1989\\18', '../secret'];
+    for (const identifier of unsafeIdentifiers) {
+      expect(identifier.includes('/') || identifier.includes('\\') || identifier.includes('..')).toBe(
+        true
+      );
+    }
+  });
+});

--- a/tests/nz-provider-request-parity.test.ts
+++ b/tests/nz-provider-request-parity.test.ts
@@ -10,9 +10,11 @@ type FixtureRequest = {
 
 describe('NZ provider request parity contract', () => {
   it('keeps the shared Rust fixture aligned with the TypeScript client request shapes', () => {
-    const fixture = JSON.parse(
-      readFileSync('tests/fixtures/rust/nz-contracts.json', 'utf8')
-    ) as { providerId: string; apiBaseUrl: string; requests: FixtureRequest[] };
+    const fixture = JSON.parse(readFileSync('tests/fixtures/rust/nz-contracts.json', 'utf8')) as {
+      providerId: string;
+      apiBaseUrl: string;
+      requests: FixtureRequest[];
+    };
 
     expect(fixture.providerId).toBe('legislation-govt-nz');
     expect(fixture.apiBaseUrl).toBe('https://api.legislation.govt.nz');
@@ -46,9 +48,9 @@ describe('NZ provider request parity contract', () => {
   it('records the same identifier safety boundary as the Rust planner', () => {
     const unsafeIdentifiers = ['act/1989/18', 'act\\1989\\18', '../secret'];
     for (const identifier of unsafeIdentifiers) {
-      expect(identifier.includes('/') || identifier.includes('\\') || identifier.includes('..')).toBe(
-        true
-      );
+      expect(
+        identifier.includes('/') || identifier.includes('\\') || identifier.includes('..')
+      ).toBe(true);
     }
   });
 });


### PR DESCRIPTION
## Summary\n- mirror the existing TypeScript NZ request paths and query parameter semantics in Rust\n- add shared fixture and TypeScript parity test\n- preserve safe identifier validation and no-network legal-data guarantees\n\n## Validation\n- cargo fmt --all -- --check\n- vitest run tests/nz-provider-request-parity.test.ts\n\nRust cargo check is deferred to CI because the local Windows linker is unavailable.