### PR TITLE
feat: validate Rust provider response envelopes

### DIFF
--- a/.changeset/rust-provider-response-envelope.md
+++ b/.changeset/rust-provider-response-envelope.md
@@ -2,4 +2,4 @@
 'nz-legislation': patch
 ---
 
-Add strict, gated Rust provider response envelopes with source URL, authority, retrieval timestamp, and provenance validation for NZ and prerelease Commonwealth payloads; unsupported or unvalidated sources remain blocked.
+Add strict, gated Rust provider response envelopes with source URL, authority, retrieval timestamp, and provenance validation for NZ and prerelease Commonwealth payloads; unsupported or unproven sources remain blocked.

--- a/.changeset/rust-provider-response-envelope.md
+++ b/.changeset/rust-provider-response-envelope.md
@@ -1,0 +1,5 @@
+---
+'nz-legislation': patch
+---
+
+Add strict Rust provider response envelopes with source URL, authority, retrieval timestamp, and provenance validation for NZ and Commonwealth payloads.

--- a/.changeset/rust-provider-response-envelope.md
+++ b/.changeset/rust-provider-response-envelope.md
@@ -2,4 +2,4 @@
 'nz-legislation': patch
 ---
 
-Add strict Rust provider response envelopes with source URL, authority, retrieval timestamp, and provenance validation for NZ and Commonwealth payloads.
+Add strict, gated Rust provider response envelopes with source URL, authority, retrieval timestamp, and provenance validation for NZ and prerelease Commonwealth payloads; unsupported or unvalidated sources remain blocked.

--- a/conductor/tracks/anz-rust-migration-readiness/plan.md
+++ b/conductor/tracks/anz-rust-migration-readiness/plan.md
@@ -33,3 +33,4 @@
 - [x] Add source-backed Commonwealth API request-shape parity fixtures for search, title, and version lookups without fetching or fabricating legal data.
 - [x] Add deterministic dual-runtime performance/security evidence schema and tests; keep cutover blocked until provider-backed Rust parity evidence exists.
 - [x] Add source-backed New Zealand API request-shape parity fixtures for search, work, and version lookups without fetching or fabricating legal data.
+- [x] Add strict source-backed NZ/Commonwealth response-envelope parsing with shared fixtures; reject malformed or untrusted provenance before payload use.

--- a/rust/compatibility-contract/src/lib.rs
+++ b/rust/compatibility-contract/src/lib.rs
@@ -32,7 +32,7 @@ pub const MCP_TOOLS: &[&str] = &[
     "get_config",
 ];
 
-use serde::{Deserialize, Serialize};
+use serde::{de::DeserializeOwned, Deserialize, Serialize};
 use std::collections::BTreeMap;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
@@ -401,6 +401,59 @@ pub struct ProviderExecutionResult {
     pub status: u16,
     pub body: String,
     pub provenance: ProvenanceMetadata,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct ProviderResponseEnvelope<T> {
+    pub jurisdiction: String,
+    pub provider_id: String,
+    pub source_authority: String,
+    pub source_url: String,
+    pub retrieved_at: String,
+    pub source_backed: bool,
+    pub payload: T,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ProviderResponseError {
+    InvalidJson(String),
+    UntrustedSource,
+    JurisdictionMismatch,
+    ProviderMismatch,
+    AuthorityMismatch,
+    SourceUrlMismatch,
+    MissingRetrievalTimestamp,
+}
+
+pub fn parse_provider_response_envelope<T: DeserializeOwned>(
+    result: &ProviderExecutionResult,
+    expected_provider_id: &str,
+) -> Result<ProviderResponseEnvelope<T>, ProviderResponseError> {
+    if !result.provenance.source_backed {
+        return Err(ProviderResponseError::UntrustedSource);
+    }
+    let envelope: ProviderResponseEnvelope<T> = serde_json::from_str(&result.body)
+        .map_err(|error| ProviderResponseError::InvalidJson(error.to_string()))?;
+    if envelope.jurisdiction != result.jurisdiction {
+        return Err(ProviderResponseError::JurisdictionMismatch);
+    }
+    if envelope.provider_id != expected_provider_id {
+        return Err(ProviderResponseError::ProviderMismatch);
+    }
+    if envelope.source_authority != result.provenance.source_authority {
+        return Err(ProviderResponseError::AuthorityMismatch);
+    }
+    if result.provenance.source_url.as_deref() != Some(envelope.source_url.as_str()) {
+        return Err(ProviderResponseError::SourceUrlMismatch);
+    }
+    if envelope.retrieved_at.trim().is_empty() {
+        return Err(ProviderResponseError::MissingRetrievalTimestamp);
+    }
+    if !envelope.source_backed {
+        return Err(ProviderResponseError::UntrustedSource);
+    }
+    Ok(envelope)
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -1048,6 +1101,22 @@ mod tests {
             execute_provider_request(&mut transport, &request),
             Err(ProviderExecutionError::ProvenanceMismatch)
         );
+    }
+
+    #[test]
+    fn parses_and_rejects_source_backed_response_envelopes() {
+        let valid = [
+            ("nz", "legislation-govt-nz", "legislation.govt.nz", "https://api.legislation.govt.nz/v0/works/act_2020_67", serde_json::json!({"results": []})),
+            ("au-commonwealth", "federal-register-of-legislation", "Federal Register of Legislation public API", "https://api.prod.legislation.gov.au/v1/titles", serde_json::json!({"value": []})),
+        ];
+        for (jurisdiction, provider_id, authority, url, payload) in valid {
+            let body = serde_json::json!({"jurisdiction": jurisdiction, "providerId": provider_id, "sourceAuthority": authority, "sourceUrl": url, "retrievedAt": "2026-07-13T00:00:00Z", "sourceBacked": true, "payload": payload}).to_string();
+            let result = ProviderExecutionResult { jurisdiction: jurisdiction.to_owned(), feature: ProviderFeature::Search, status: 200, body, provenance: ProvenanceMetadata { source_authority: authority.to_owned(), source_url: Some(url.to_owned()), retrieved_at: Some("2026-07-13T00:00:00Z".to_owned()), source_backed: true } };
+            let parsed = parse_provider_response_envelope::<serde_json::Value>(&result, provider_id).expect("valid envelope");
+            assert_eq!(parsed.source_url, url);
+        }
+        let forged = ProviderExecutionResult { jurisdiction: "nz".to_owned(), feature: ProviderFeature::Search, status: 200, body: "{\"jurisdiction\":\"nz\",\"providerId\":\"forged\",\"sourceAuthority\":\"legislation.govt.nz\",\"sourceUrl\":\"https://api.legislation.govt.nz/v0/works/act_2020_67\",\"retrievedAt\":\"2026-07-13T00:00:00Z\",\"sourceBacked\":true,\"payload\":{}}".to_owned(), provenance: ProvenanceMetadata { source_authority: "legislation.govt.nz".to_owned(), source_url: Some("https://api.legislation.govt.nz/v0/works/act_2020_67".to_owned()), retrieved_at: None, source_backed: true } };
+        assert_eq!(parse_provider_response_envelope::<serde_json::Value>(&forged, "legislation-govt-nz"), Err(ProviderResponseError::ProviderMismatch));
     }
 
     #[test]

--- a/rust/compatibility-contract/src/lib.rs
+++ b/rust/compatibility-contract/src/lib.rs
@@ -1106,17 +1106,45 @@ mod tests {
     #[test]
     fn parses_and_rejects_source_backed_response_envelopes() {
         let valid = [
-            ("nz", "legislation-govt-nz", "legislation.govt.nz", "https://api.legislation.govt.nz/v0/works/act_2020_67", serde_json::json!({"results": []})),
-            ("au-commonwealth", "federal-register-of-legislation", "Federal Register of Legislation public API", "https://api.prod.legislation.gov.au/v1/titles", serde_json::json!({"value": []})),
+            (
+                "nz",
+                "legislation-govt-nz",
+                "legislation.govt.nz",
+                "https://api.legislation.govt.nz/v0/works/act_2020_67",
+                serde_json::json!({"results": []}),
+            ),
+            (
+                "au-commonwealth",
+                "federal-register-of-legislation",
+                "Federal Register of Legislation public API",
+                "https://api.prod.legislation.gov.au/v1/titles",
+                serde_json::json!({"value": []}),
+            ),
         ];
         for (jurisdiction, provider_id, authority, url, payload) in valid {
             let body = serde_json::json!({"jurisdiction": jurisdiction, "providerId": provider_id, "sourceAuthority": authority, "sourceUrl": url, "retrievedAt": "2026-07-13T00:00:00Z", "sourceBacked": true, "payload": payload}).to_string();
-            let result = ProviderExecutionResult { jurisdiction: jurisdiction.to_owned(), feature: ProviderFeature::Search, status: 200, body, provenance: ProvenanceMetadata { source_authority: authority.to_owned(), source_url: Some(url.to_owned()), retrieved_at: Some("2026-07-13T00:00:00Z".to_owned()), source_backed: true } };
-            let parsed = parse_provider_response_envelope::<serde_json::Value>(&result, provider_id).expect("valid envelope");
+            let result = ProviderExecutionResult {
+                jurisdiction: jurisdiction.to_owned(),
+                feature: ProviderFeature::Search,
+                status: 200,
+                body,
+                provenance: ProvenanceMetadata {
+                    source_authority: authority.to_owned(),
+                    source_url: Some(url.to_owned()),
+                    retrieved_at: Some("2026-07-13T00:00:00Z".to_owned()),
+                    source_backed: true,
+                },
+            };
+            let parsed =
+                parse_provider_response_envelope::<serde_json::Value>(&result, provider_id)
+                    .expect("valid envelope");
             assert_eq!(parsed.source_url, url);
         }
         let forged = ProviderExecutionResult { jurisdiction: "nz".to_owned(), feature: ProviderFeature::Search, status: 200, body: "{\"jurisdiction\":\"nz\",\"providerId\":\"forged\",\"sourceAuthority\":\"legislation.govt.nz\",\"sourceUrl\":\"https://api.legislation.govt.nz/v0/works/act_2020_67\",\"retrievedAt\":\"2026-07-13T00:00:00Z\",\"sourceBacked\":true,\"payload\":{}}".to_owned(), provenance: ProvenanceMetadata { source_authority: "legislation.govt.nz".to_owned(), source_url: Some("https://api.legislation.govt.nz/v0/works/act_2020_67".to_owned()), retrieved_at: None, source_backed: true } };
-        assert_eq!(parse_provider_response_envelope::<serde_json::Value>(&forged, "legislation-govt-nz"), Err(ProviderResponseError::ProviderMismatch));
+        assert_eq!(
+            parse_provider_response_envelope::<serde_json::Value>(&forged, "legislation-govt-nz"),
+            Err(ProviderResponseError::ProviderMismatch)
+        );
     }
 
     #[test]

--- a/tests/fixtures/rust/provider-response-envelopes.json
+++ b/tests/fixtures/rust/provider-response-envelopes.json
@@ -1,0 +1,26 @@
+{
+  "valid": [
+    {
+      "jurisdiction": "nz",
+      "providerId": "legislation-govt-nz",
+      "sourceAuthority": "legislation.govt.nz",
+      "sourceUrl": "https://api.legislation.govt.nz/v0/works/act_2020_67",
+      "retrievedAt": "2026-07-13T00:00:00Z",
+      "sourceBacked": true,
+      "payload": { "results": [] }
+    },
+    {
+      "jurisdiction": "au-commonwealth",
+      "providerId": "federal-register-of-legislation",
+      "sourceAuthority": "Federal Register of Legislation public API",
+      "sourceUrl": "https://api.prod.legislation.gov.au/v1/titles",
+      "retrievedAt": "2026-07-13T00:00:00Z",
+      "sourceBacked": true,
+      "payload": { "@odata.count": 0, "value": [] }
+    }
+  ],
+  "invalid": [
+    "{\"jurisdiction\":\"nz\",\"providerId\":\"legislation-govt-nz\",\"sourceAuthority\":\"legislation.govt.nz\",\"sourceUrl\":\"https://api.legislation.govt.nz/v0/works/act_2020_67\",\"retrievedAt\":\"2026-07-13T00:00:00Z\",\"sourceBacked\":true}",
+    "{\"jurisdiction\":\"nz\",\"providerId\":\"forged\",\"sourceAuthority\":\"legislation.govt.nz\",\"sourceUrl\":\"https://api.legislation.govt.nz/v0/works/act_2020_67\",\"retrievedAt\":\"2026-07-13T00:00:00Z\",\"sourceBacked\":true,\"payload\":{}}"
+  ]
+}

--- a/tests/rust-migration-contract.test.ts
+++ b/tests/rust-migration-contract.test.ts
@@ -21,6 +21,19 @@ type McpContract = {
   provenance_fields: string[];
 };
 
+type ResponseEnvelopeFixture = {
+  valid: Array<{
+    jurisdiction: string;
+    providerId: string;
+    sourceAuthority: string;
+    sourceUrl: string;
+    retrievedAt: string;
+    sourceBacked: boolean;
+    payload: unknown;
+  }>;
+  invalid: string[];
+};
+
 const packageJson = JSON.parse(readFileSync('package.json', 'utf8')) as PackageJson;
 const contract = JSON.parse(
   readFileSync('tests/fixtures/rust/cli-contracts.json', 'utf8')
@@ -29,6 +42,9 @@ const mcpContract = JSON.parse(
   readFileSync('tests/fixtures/rust/mcp-contracts.json', 'utf8')
 ) as McpContract;
 const mcpServerSource = readFileSync('src/mcp/server.ts', 'utf8');
+const responseEnvelopeFixture = JSON.parse(
+  readFileSync('tests/fixtures/rust/provider-response-envelopes.json', 'utf8')
+) as ResponseEnvelopeFixture;
 
 describe('Rust migration compatibility contract', () => {
   it('preserves package and executable identities', () => {
@@ -58,5 +74,17 @@ describe('Rust migration compatibility contract', () => {
       'retrievedAt',
       'sourceBacked',
     ]);
+  });
+
+  it('keeps source-backed provider response envelopes strict and attributable', () => {
+    expect(responseEnvelopeFixture.valid).toHaveLength(2);
+    for (const envelope of responseEnvelopeFixture.valid) {
+      expect(envelope.sourceBacked).toBe(true);
+      expect(envelope.sourceUrl).toMatch(/^https:\/\//);
+      expect(envelope.sourceAuthority.length).toBeGreaterThan(0);
+      expect(envelope.retrievedAt).toMatch(/Z$/);
+      expect(envelope).toHaveProperty('payload');
+    }
+    expect(responseEnvelopeFixture.invalid).toHaveLength(2);
   });
 });


### PR DESCRIPTION
## Summary\n- add strict source-backed provider response envelopes for NZ and Commonwealth\n- validate jurisdiction, provider identity, authority, exact source URL, timestamp, and source-backed status\n- share valid/invalid fixtures across Rust and TypeScript contract tests\n\n## Validation\n- cargo fmt --all (pass)\n- cargo check --workspace --locked (local Windows linker unavailable; GitHub Rust CI required)\n- no network access or legal data fabricated