### PR TITLE
feat: add machine-readable registry readiness

### DIFF
--- a/.changeset/registry-readiness-contract.md
+++ b/.changeset/registry-readiness-contract.md
@@ -1,0 +1,5 @@
+---
+'nz-legislation-tool': patch
+---
+
+Add a machine-readable, submission-blocked readiness matrix for assistant and MCP registry targets.

--- a/conductor/tracks/anz-registry-mcp-directories/metadata.json
+++ b/conductor/tracks/anz-registry-mcp-directories/metadata.json
@@ -1,11 +1,11 @@
 {
   "trackId": "anz-registry-mcp-directories",
-  "status": "planned",
+  "status": "in_progress",
   "priority": "P0",
   "created": "2026-05-23",
   "sourceTrack": "anz-platform-release-and-distribution",
   "singleRepo": true,
-  "phase": "preparation-only",
+  "phase": "registry-readiness",
   "channels": ["Smithery", "other MCP directories"],
   "externalSubmissionAllowed": false,
   "publishingAllowed": false,

--- a/conductor/tracks/anz-registry-mcp-directories/plan.md
+++ b/conductor/tracks/anz-registry-mcp-directories/plan.md
@@ -20,4 +20,6 @@
 - [x] Prepare guarded local listing metadata after provider-aware MCP/export
       gates were added.
 - [x] Add `pnpm gate:channel-readiness` to enforce local-only registry metadata.
+- [x] Add machine-readable blocked readiness status for assistant and MCP
+      directory targets; keep external submission disabled.
 - [ ] Record security/provenance review before submission.

--- a/integrations/registry-readiness.json
+++ b/integrations/registry-readiness.json
@@ -1,0 +1,182 @@
+{
+  "schemaVersion": 1,
+  "status": "preparation-only",
+  "externalSubmissionAllowed": false,
+  "generatedAt": "2026-07-13",
+  "packageName": "nz-legislation-tool",
+  "targets": [
+    {
+      "id": "claude",
+      "category": "assistant",
+      "name": "Claude",
+      "status": "blocked",
+      "artifact": "integrations/claude/README.md",
+      "officialSource": "https://docs.anthropic.com/en/docs/mcp",
+      "blockers": ["target-requirements-review", "security-provenance-review", "maintainer-approval"],
+      "submission": {
+        "allowed": false,
+        "reason": "Preparation-only; target requirements and security evidence are not yet approved."
+      }
+    },
+    {
+      "id": "codex",
+      "category": "assistant",
+      "name": "Codex",
+      "status": "blocked",
+      "artifact": "integrations/codex/README.md",
+      "officialSource": "https://help.openai.com/en/articles/20001256-plugins-in-codex",
+      "blockers": ["plugin-manifest-review", "app-permission-review", "maintainer-approval"],
+      "submission": {
+        "allowed": false,
+        "reason": "Preparation-only; plugin and app approval evidence is not yet recorded."
+      }
+    },
+    {
+      "id": "github-copilot",
+      "category": "assistant",
+      "name": "GitHub Copilot",
+      "status": "blocked",
+      "artifact": "integrations/github-copilot/README.md",
+      "officialSource": "https://docs.github.com/en/copilot/concepts/agents/about-plugins",
+      "blockers": ["plugin-manifest-review", "marketplace-requirements-review", "security-provenance-review"],
+      "submission": {
+        "allowed": false,
+        "reason": "Preparation-only; plugin manifest and marketplace evidence are not yet approved."
+      }
+    },
+    {
+      "id": "gemini",
+      "category": "assistant",
+      "name": "Gemini",
+      "status": "blocked",
+      "artifact": "integrations/gemini/README.md",
+      "officialSource": "https://ai.google.dev/gemini-api/docs/tools",
+      "blockers": ["hosting-auth-review", "tool-schema-review", "maintainer-approval"],
+      "submission": {
+        "allowed": false,
+        "reason": "Preparation-only; hosting, authentication, quota, and distribution evidence are pending."
+      }
+    },
+    {
+      "id": "qwen",
+      "category": "assistant",
+      "name": "Qwen",
+      "status": "blocked",
+      "artifact": "integrations/qwen/README.md",
+      "officialSource": "https://github.com/QwenLM/Qwen-Agent",
+      "blockers": ["wrapper-contract-review", "transport-review", "distribution-requirements-review"],
+      "submission": {
+        "allowed": false,
+        "reason": "Preparation-only; wrapper, transport, credential, and distribution evidence are pending."
+      }
+    },
+    {
+      "id": "smithery",
+      "category": "mcp-registry",
+      "name": "Smithery",
+      "status": "blocked",
+      "artifact": "integrations/mcp/registry-metadata/smithery.json",
+      "officialSource": "https://smithery.ai/",
+      "blockers": [
+        "provider-aware-mcp-export",
+        "tested-install-snippets",
+        "security-provenance-review",
+        "listing-truthfulness"
+      ],
+      "submission": {
+        "allowed": false,
+        "reason": "Preparation-only; registry requirements and release evidence are not complete."
+      }
+    },
+    {
+      "id": "mcp-so",
+      "category": "mcp-registry",
+      "name": "mcp.so",
+      "status": "blocked",
+      "artifact": "integrations/mcp/registry-metadata/mcp-so.json",
+      "officialSource": "https://mcp.so/",
+      "blockers": [
+        "provider-aware-mcp-export",
+        "tested-install-snippets",
+        "security-provenance-review",
+        "listing-truthfulness"
+      ],
+      "submission": {
+        "allowed": false,
+        "reason": "Preparation-only; registry requirements and release evidence are not complete."
+      }
+    },
+    {
+      "id": "mcp-market",
+      "category": "mcp-registry",
+      "name": "MCP Market",
+      "status": "blocked",
+      "artifact": "integrations/mcp/registry-metadata/mcp-market.json",
+      "officialSource": "https://mcpmarket.com/",
+      "blockers": [
+        "provider-aware-mcp-export",
+        "tested-install-snippets",
+        "security-provenance-review",
+        "listing-truthfulness"
+      ],
+      "submission": {
+        "allowed": false,
+        "reason": "Preparation-only; registry requirements and release evidence are not complete."
+      }
+    },
+    {
+      "id": "mcp-store",
+      "category": "mcp-registry",
+      "name": "MCP Store",
+      "status": "blocked",
+      "artifact": "integrations/mcp/registry-metadata/mcp-store.json",
+      "officialSource": "https://mcpstore.ai/",
+      "blockers": [
+        "provider-aware-mcp-export",
+        "tested-install-snippets",
+        "security-provenance-review",
+        "listing-truthfulness"
+      ],
+      "submission": {
+        "allowed": false,
+        "reason": "Preparation-only; registry requirements and release evidence are not complete."
+      }
+    },
+    {
+      "id": "pulsemcp",
+      "category": "mcp-registry",
+      "name": "PulseMCP",
+      "status": "blocked",
+      "artifact": "integrations/mcp/registry-metadata/pulsemcp.json",
+      "officialSource": "https://www.pulsemcp.com/",
+      "blockers": [
+        "provider-aware-mcp-export",
+        "tested-install-snippets",
+        "security-provenance-review",
+        "listing-truthfulness"
+      ],
+      "submission": {
+        "allowed": false,
+        "reason": "Preparation-only; registry requirements and release evidence are not complete."
+      }
+    },
+    {
+      "id": "glama",
+      "category": "mcp-registry",
+      "name": "Glama-style directories",
+      "status": "blocked",
+      "artifact": "integrations/mcp/registry-metadata/glama.json",
+      "officialSource": "https://glama.ai/mcp",
+      "blockers": [
+        "provider-aware-mcp-export",
+        "tested-install-snippets",
+        "security-provenance-review",
+        "listing-truthfulness"
+      ],
+      "submission": {
+        "allowed": false,
+        "reason": "Preparation-only; registry requirements and release evidence are not complete."
+      }
+    }
+  ]
+}

--- a/scripts/check-assistant-integrations.ts
+++ b/scripts/check-assistant-integrations.ts
@@ -1,6 +1,77 @@
 import { existsSync, readFileSync } from 'node:fs';
 
 const failures: string[] = [];
+const readinessPath = 'integrations/registry-readiness.json';
+interface ReadinessTarget {
+  id: string;
+  category: 'assistant' | 'mcp-registry';
+  status: string;
+  artifact: string;
+  officialSource: string;
+  blockers: string[];
+  submission: { allowed: boolean; reason: string };
+}
+interface ReadinessContract {
+  schemaVersion: number;
+  status: string;
+  externalSubmissionAllowed: boolean;
+  packageName: string;
+  targets: ReadinessTarget[];
+}
+if (!existsSync(readinessPath)) {
+  failures.push(`Missing ${readinessPath}`);
+}
+let readiness: ReadinessContract | undefined;
+if (existsSync(readinessPath)) {
+  try {
+    readiness = JSON.parse(readFileSync(readinessPath, 'utf8')) as ReadinessContract;
+  } catch {
+    failures.push(`${readinessPath} must contain valid JSON.`);
+  }
+}
+if (readiness) {
+  if (readiness.schemaVersion !== 1) failures.push(`${readinessPath} schemaVersion must be 1.`);
+  if (readiness.status !== 'preparation-only')
+    failures.push(`${readinessPath} must remain preparation-only.`);
+  if (readiness.externalSubmissionAllowed !== false)
+    failures.push(`${readinessPath} must block external submissions.`);
+  if (readiness.packageName !== 'nz-legislation-tool')
+    failures.push(`${readinessPath} packageName must be nz-legislation-tool.`);
+  const expected = new Set([
+    'claude',
+    'codex',
+    'github-copilot',
+    'gemini',
+    'qwen',
+    'smithery',
+    'mcp-so',
+    'mcp-market',
+    'mcp-store',
+    'pulsemcp',
+    'glama',
+  ]);
+  const seen = new Set<string>();
+  for (const target of readiness.targets ?? []) {
+    seen.add(target.id);
+    if (!expected.has(target.id))
+      failures.push(`${readinessPath} contains unknown target ${target.id}.`);
+    if (target.status !== 'blocked')
+      failures.push(`${readinessPath} target ${target.id} must remain blocked.`);
+    if (!target.artifact || !existsSync(target.artifact))
+      failures.push(`${readinessPath} target ${target.id} must link an existing artifact.`);
+    if (!/^https:\/\//.test(target.officialSource))
+      failures.push(`${readinessPath} target ${target.id} must link an HTTPS official source.`);
+    if (!Array.isArray(target.blockers) || target.blockers.length === 0)
+      failures.push(`${readinessPath} target ${target.id} must list blockers.`);
+    if (
+      target.submission?.allowed !== false ||
+      !/preparation|blocked|evidence|review/i.test(target.submission?.reason ?? '')
+    )
+      failures.push(`${readinessPath} target ${target.id} must block submission with a reason.`);
+  }
+  for (const target of expected)
+    if (!seen.has(target)) failures.push(`${readinessPath} is missing target ${target}.`);
+}
 const matrixPath = 'integrations/assistant-marketplace-readiness.md';
 const matrix = existsSync(matrixPath) ? readFileSync(matrixPath, 'utf8') : '';
 if (!matrix) failures.push(`Missing ${matrixPath}`);


### PR DESCRIPTION
## Summary\n- add machine-readable blocked readiness matrix for assistant and MCP directory targets\n- enforce artifact, source, blocker, and submission boundaries in assistant integration gate\n- update Conductor track 59 and changeset\n\nExternal submissions remain disabled.\n\n## Validation\n- node node_modules/tsx/dist/cli.mjs scripts/check-assistant-integrations.ts\n- node node_modules/tsx/dist/cli.mjs scripts/check-channel-readiness.ts\n- prettier --check changed files