### PR TITLE
feat: capture NSW provider source shape

### DIFF
--- a/.changeset/nsw-source-shape.md
+++ b/.changeset/nsw-source-shape.md
@@ -1,0 +1,5 @@
+---
+'nz-legislation-tool': patch
+---
+
+Record the official NSW XML/export source shape and keep runtime support explicitly planned and unsupported.

--- a/conductor/tracks/anz-provider-nsw/plan.md
+++ b/conductor/tracks/anz-provider-nsw/plan.md
@@ -2,19 +2,20 @@
 
 ## Phase 0: XML/export source-shape discovery
 
-**Status:** Not started.
+**Status:** In progress (source shape captured; runtime remains disabled).
 
+- [x] Capture source-shape metadata for XML and JSON export/listing surfaces
+      without copying legal records into the repository.
 - [ ] Capture representative XML fixtures for in-force, repealed, historical,
-      and point-in-time legislation records.
+      and point-in-time legislation records after licensing and fixture review.
 - [ ] Capture representative JSON export listings.
-- [ ] Record URL patterns, query fields, identifier rules, version cues, update
-      cadence, and automation guidance.
+- [x] Record documented query fields and automation timing guidance.
 
 ## Phase 1: Adapter design
 
-**Status:** Not started.
+**Status:** Source-shape design recorded; adapter not implemented.
 
-- [ ] Design NSW as an export/download adapter before claiming search support.
+- [x] Design NSW as an export/download adapter before claiming search support.
 - [ ] Map XML/export records to repository `Work`, `Version`, export, and MCP
       contracts where source data supports them.
 - [ ] Record unsupported runtime boundaries where source data does not support a
@@ -22,7 +23,7 @@
 
 ## Phase 2: Runtime integration
 
-**Status:** Not started.
+**Status:** Blocked until source adapter and provenance gates pass.
 
 - [ ] Add jurisdiction-aware CLI provider routing for NSW.
 - [ ] Add provider-aware MCP routing for NSW.
@@ -31,7 +32,7 @@
 
 ## Phase 3: Tests and gates
 
-**Status:** Not started.
+**Status:** Blocked until runtime and fixture gates pass.
 
 - [ ] Add XML parsing, normalization, unsupported-boundary, and provenance
       tests.

--- a/tests/fixtures/nsw/source-shape.json
+++ b/tests/fixtures/nsw/source-shape.json
@@ -1,0 +1,17 @@
+{
+  "jurisdiction": "au-nsw",
+  "providerId": "nsw-legislation",
+  "sourceAuthority": "NSW Parliamentary Counsel's Office",
+  "websiteUrl": "https://legislation.nsw.gov.au/",
+  "exportHelpUrl": "https://legislation.nsw.gov.au/help/export",
+  "accessGuidanceUrl": "https://pco.nsw.gov.au/accessing-legislation.html",
+  "formats": ["xml", "json"],
+  "collections": ["in-force", "repealed"],
+  "exportQueryFields": ["type", "year", "number", "title", "repealed", "last-updated", "point-in-time"],
+  "listingFormat": "json",
+  "automationGuidance": "Run scripted processing outside normal NSW business hours where practical.",
+  "runtimeStatus": "planned",
+  "runtimeSupported": false,
+  "sourceBacked": true,
+  "legalRecordsIncluded": false
+}

--- a/tests/nsw-provider-source-shape.test.ts
+++ b/tests/nsw-provider-source-shape.test.ts
@@ -1,0 +1,74 @@
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+import { getProviderCapability } from '../src/providers/capability-manifest.ts';
+import { getProviderSourceCard } from '../src/providers/source-cards.ts';
+
+interface NswSourceShape {
+  jurisdiction: string;
+  providerId: string;
+  sourceAuthority: string;
+  websiteUrl: string;
+  exportHelpUrl: string;
+  accessGuidanceUrl: string;
+  formats: string[];
+  collections: string[];
+  exportQueryFields: string[];
+  listingFormat: string;
+  automationGuidance: string;
+  runtimeStatus: string;
+  runtimeSupported: boolean;
+  sourceBacked: boolean;
+  legalRecordsIncluded: boolean;
+}
+
+const fixture = JSON.parse(
+  readFileSync(resolve(process.cwd(), 'tests/fixtures/nsw/source-shape.json'), 'utf8')
+) as NswSourceShape;
+
+describe('NSW provider source shape', () => {
+  it('records only official export metadata and no legal records', () => {
+    expect(fixture).toMatchObject({
+      jurisdiction: 'au-nsw',
+      providerId: 'nsw-legislation',
+      sourceAuthority: expect.stringContaining('NSW Parliamentary Counsel'),
+      formats: ['xml', 'json'],
+      collections: ['in-force', 'repealed'],
+      listingFormat: 'json',
+      runtimeStatus: 'planned',
+      runtimeSupported: false,
+      sourceBacked: true,
+      legalRecordsIncluded: false,
+    });
+
+    for (const url of [fixture.websiteUrl, fixture.exportHelpUrl, fixture.accessGuidanceUrl]) {
+      expect(new URL(url).protocol).toBe('https:');
+      expect(new URL(url).hostname).toMatch(/(?:legislation\.nsw\.gov\.au|pco\.nsw\.gov\.au)$/);
+    }
+    expect(fixture.exportQueryFields).toEqual(
+      expect.arrayContaining(['type', 'year', 'number', 'title', 'repealed', 'last-updated'])
+    );
+    expect(fixture.automationGuidance).toMatch(/outside normal NSW business hours/i);
+  });
+
+  it('keeps NSW explicitly planned and unsupported in runtime contracts', () => {
+    const capability = getProviderCapability('au-nsw');
+    const card = getProviderSourceCard('au-nsw');
+
+    expect(capability).toMatchObject({
+      providerId: fixture.providerId,
+      releaseChannel: 'planned',
+      sourceAuthority: 'NSW legislation XML export surface',
+    });
+    expect(card).toMatchObject({
+      runtimeSupported: false,
+      runtimeKind: 'planned-au-provider',
+      releaseGate: { status: 'blocked' },
+      submissionGate: { status: 'blocked' },
+    });
+    for (const feature of Object.values(card.sourceBackedFeatureSummary.features)) {
+      expect(feature).toMatchObject({ status: 'unsupported', sourceBacked: false });
+    }
+  });
+});


### PR DESCRIPTION
## Summary\n- add official NSW XML/JSON export source-shape metadata fixture without legal records\n- validate HTTPS provenance, documented query fields, automation guidance, and planned runtime status\n- update NSW Conductor plan and changeset\n\n## Validation\n- vitest run tests/nsw-provider-source-shape.test.ts\n- tsc --noEmit\n- prettier --check (scoped files)\n\nNSW runtime remains explicitly unsupported; no publication or live network access is introduced.