### PR TITLE
test: harden ACT provider source-shape gate

### DIFF
--- a/.changeset/act-source-shape-gate.md
+++ b/.changeset/act-source-shape-gate.md
@@ -1,0 +1,5 @@
+---
+'nz-legislation-tool': patch
+---
+
+Re-verify the ACT source-shape contract and keep provider runtime and registry submission explicitly blocked pending source-backed adapter evidence.

--- a/conductor/archive/anz-provider-act/plan.md
+++ b/conductor/archive/anz-provider-act/plan.md
@@ -58,6 +58,15 @@
 - ACT runtime remains `planned`/unsupported; no publication or deployment is authorized.
 - Implementation commit: `b63b6f3`; latest Docs workflow passed (`29156760779`).
 
+## Review evidence - 2026-07-13
+
+- [x] Re-verified official ACT register entry points are HTTPS-only and remain
+      confined to the ACT Government host.
+- [x] Added a source-card gate test proving ACT runtime, release, and
+      submission remain blocked while the fixture policy stays metadata-only.
+- [x] No legal text, inferred records, or machine-readable access claims were
+      added; adapter implementation remains future work.
+
 ## Review evidence - 2026-07-12
 
 - [x] Clarified access-term and machine-readable-source uncertainty fields.

--- a/tests/act-provider-source-shape.test.ts
+++ b/tests/act-provider-source-shape.test.ts
@@ -1,0 +1,49 @@
+import { readFileSync } from 'node:fs';
+import { describe, expect, it } from 'vitest';
+
+import { getProviderSourceCard } from '../src/providers/source-cards.ts';
+
+type ActSourceShape = {
+  jurisdiction: string;
+  providerId: string;
+  sourceAuthority: string;
+  sourceEntryPoints: string[];
+  runtimeStatus: string;
+  fixturePolicy: string;
+};
+
+const sourceShape = JSON.parse(
+  readFileSync('docs/maintainers/act-provider-source-shape.json', 'utf8')
+) as ActSourceShape;
+
+describe('ACT provider source-shape contract', () => {
+  it('restricts source entry points to official ACT register hosts', () => {
+    expect(sourceShape.sourceEntryPoints.length).toBeGreaterThanOrEqual(2);
+    for (const sourceUrl of sourceShape.sourceEntryPoints) {
+      const url = new URL(sourceUrl);
+      expect(url.protocol).toBe('https:');
+      expect(url.hostname).toBe('www.legislation.act.gov.au');
+    }
+  });
+
+  it('keeps the source card gated while preserving metadata-only policy', () => {
+    expect(sourceShape).toMatchObject({
+      jurisdiction: 'au-act',
+      providerId: 'act-legislation',
+      sourceAuthority: 'ACT Legislation Register',
+      runtimeStatus: 'unsupported',
+    });
+    expect(sourceShape.fixturePolicy).toMatch(/metadata-only/i);
+
+    const card = getProviderSourceCard('au-act');
+    expect(card).toMatchObject({
+      jurisdiction: 'au-act',
+      providerId: 'act-legislation',
+      runtimeSupported: false,
+      runtimeKind: 'planned-au-provider',
+      releaseGate: { status: 'blocked' },
+      submissionGate: { status: 'blocked' },
+    });
+    expect(card.sourceBackedFeatureSummary.sourceBacked).toHaveLength(0);
+  });
+});


### PR DESCRIPTION
## Summary\n- re-verify ACT official source entry points and host boundaries\n- add source-card assertions for blocked runtime/release/submission\n- record Conductor review evidence and preserve metadata-only policy\n\nIssue: #47\n\nNo legal records or runtime support are introduced.