### PR TITLE
feat: capture Queensland provider source shape

### DIFF
--- a/.changeset/qld-source-shape.md
+++ b/.changeset/qld-source-shape.md
@@ -1,0 +1,5 @@
+---
+'nz-legislation-tool': patch
+---
+
+Record the official Queensland Legislation API source shape and keep Queensland runtime support explicitly planned and unsupported.

--- a/conductor/tracks/anz-provider-queensland/metadata.json
+++ b/conductor/tracks/anz-provider-queensland/metadata.json
@@ -5,7 +5,7 @@
   "created": "2026-05-21",
   "sourceTrack": "anz-platform-release-and-distribution",
   "singleRepo": true,
-  "phase": "api-access-and-source-backed-adapter",
+  "phase": "source-shape-discovery",
   "jurisdiction": "Queensland",
   "jurisdictionCode": "au-qld",
   "providerId": "queensland-legislation",
@@ -23,6 +23,7 @@
     "provider-capability-manifest",
     "provider-aware-mcp-export",
     "api-registration-and-swagger-capture",
+    "source-shape-fixture-and-tests",
     "provenance-source-cards",
     "docs-and-release-notes"
   ]

--- a/conductor/tracks/anz-provider-queensland/plan.md
+++ b/conductor/tracks/anz-provider-queensland/plan.md
@@ -2,19 +2,21 @@
 
 ## Phase 0: Access and source-shape capture
 
-**Status:** Not started.
+**Status:** In progress (official source shape recorded; runtime remains disabled).
 
 - [ ] Register for Queensland API access using maintainer-controlled
       credentials outside the repository.
-- [ ] Capture current Swagger/OpenAPI documentation from the API base URL.
+- [ ] Capture current Swagger/OpenAPI documentation from the API base URL after maintainer registration.
 - [ ] Record authentication, rate limits, licence terms, authoritative formats,
       and update cadence.
+- [x] Record metadata-only official API source shape and URL/access boundaries;
+      no legal records are stored in this repository.
 - [ ] Capture real official API-shaped fixtures for representative legislation
-      records.
+      records after licensing and fixture review.
 
 ## Phase 1: Adapter design
 
-**Status:** Not started.
+**Status:** Blocked until registered API shape and fixtures are reviewed.
 
 - [ ] Define Queensland provider adapter boundaries and unsupported feature
       behavior.
@@ -24,7 +26,7 @@
 
 ## Phase 2: Runtime integration
 
-**Status:** Not started.
+**Status:** Blocked; runtime remains explicitly unsupported.
 
 - [ ] Add jurisdiction-aware CLI provider routing for Queensland.
 - [ ] Add provider-aware MCP routing for Queensland.
@@ -33,17 +35,19 @@
 
 ## Phase 3: Tests and gates
 
-**Status:** Not started.
+**Status:** Source-shape tests added; runtime and live-source gates remain blocked.
 
 - [ ] Add unit tests for API mapping and unsupported cases.
 - [ ] Add no-placeholder legal-data tests using official-source fixtures.
 - [ ] Add opt-in live smoke tests that respect API access terms.
+- [x] Add metadata-only source-shape fixture and readiness tests with no legal
+      records or fabricated data.
 - [ ] Keep `pnpm typecheck`, `pnpm test:run`, `pnpm build`, and
       `pnpm gate:no-placeholder-legal-data` passing.
 
 ## Phase 4: Release readiness
 
-**Status:** Not started.
+**Status:** Blocked until provider runtime, provenance, and release gates pass.
 
 - [ ] Update docs and release notes only after provider gates pass.
 - [ ] Distinguish NZ stable support from Queensland prerelease support.

--- a/docs/maintainers/queensland-provider-source-shape.json
+++ b/docs/maintainers/queensland-provider-source-shape.json
@@ -1,0 +1,38 @@
+{
+  "jurisdiction": "au-qld",
+  "providerId": "queensland-legislation",
+  "sourceAuthority": "Queensland Office of the Queensland Parliamentary Counsel",
+  "sourceEntryPoints": [
+    "https://www.legislation.qld.gov.au/",
+    "https://www.legislation.qld.gov.au/api",
+    "https://api.legislation.qld.gov.au/",
+    "https://api.legislation.qld.gov.au/api/signup",
+    "https://www.legislation.qld.gov.au/api/usage-guidelines"
+  ],
+  "apiBaseUrl": "https://api.legislation.qld.gov.au/",
+  "access": {
+    "registrationRequired": true,
+    "authentication": "maintainer-controlled API account; credentials must not be committed",
+    "rateLimits": "subject to the Queensland API usage agreement and may be changed by OQPC",
+    "licence": "CC BY 4.0 unless the Queensland legislation copyright statement says otherwise"
+  },
+  "formats": ["json", "xml", "html", "pdf"],
+  "authority": {
+    "sourceIsOfficial": true,
+    "authoritativeFormats": ["json", "xml", "html", "pdf"],
+    "notesAndAnnotationsStatus": "aids only; not part of the legislation"
+  },
+  "adapterMapping": {
+    "search": "Not enabled until the registered API Swagger contract is captured and mapped.",
+    "retrieval": "Future adapter may retrieve API representations after access and provenance review.",
+    "versioning": "Use API-provided identifiers and effective-date fields; do not infer versions from filenames.",
+    "export": "Unsupported until source-backed export mapping and tests exist.",
+    "provenance": "Emit source authority, jurisdiction, endpoint, format, and retrieval timestamp.",
+    "unsupported": "Return structured unsupported_provider_capability for runtime operations until gates pass."
+  },
+  "runtimeStatus": "planned",
+  "runtimeSupported": false,
+  "sourceBacked": true,
+  "legalRecordsIncluded": false,
+  "fixturePolicy": "metadata-only source-shape fixture; no legal text or fabricated records"
+}

--- a/tests/queensland-provider-source-shape.test.ts
+++ b/tests/queensland-provider-source-shape.test.ts
@@ -1,0 +1,75 @@
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+import { getProviderCapability } from '../src/providers/capability-manifest.ts';
+import { getProviderSourceCard } from '../src/providers/source-cards.ts';
+
+interface QueenslandSourceShape {
+  jurisdiction: string;
+  providerId: string;
+  sourceAuthority: string;
+  sourceEntryPoints: string[];
+  apiBaseUrl: string;
+  access: { registrationRequired: boolean; authentication: string; rateLimits: string };
+  formats: string[];
+  runtimeStatus: string;
+  runtimeSupported: boolean;
+  sourceBacked: boolean;
+  legalRecordsIncluded: boolean;
+  fixturePolicy: string;
+}
+
+const fixture = JSON.parse(
+  readFileSync(
+    resolve(process.cwd(), 'docs/maintainers/queensland-provider-source-shape.json'),
+    'utf8'
+  )
+) as QueenslandSourceShape;
+
+describe('Queensland provider source shape', () => {
+  it('records official API metadata without legal records', () => {
+    expect(fixture).toMatchObject({
+      jurisdiction: 'au-qld',
+      providerId: 'queensland-legislation',
+      sourceAuthority: expect.stringContaining('Queensland'),
+      formats: ['json', 'xml', 'html', 'pdf'],
+      access: { registrationRequired: true },
+      runtimeStatus: 'planned',
+      runtimeSupported: false,
+      sourceBacked: true,
+      legalRecordsIncluded: false,
+    });
+
+    for (const url of fixture.sourceEntryPoints) {
+      expect(new URL(url).protocol).toBe('https:');
+      expect(new URL(url).hostname).toMatch(
+        /(?:legislation\.qld\.gov\.au|api\.legislation\.qld\.gov\.au)$/
+      );
+    }
+    expect(fixture.apiBaseUrl).toBe('https://api.legislation.qld.gov.au/');
+    expect(fixture.access.authentication).toMatch(/credentials must not be committed/i);
+    expect(fixture.access.rateLimits).toMatch(/usage agreement/i);
+    expect(fixture.fixturePolicy).toContain('metadata-only');
+  });
+
+  it('keeps Queensland explicitly planned and unsupported in runtime contracts', () => {
+    const capability = getProviderCapability('au-qld');
+    const card = getProviderSourceCard('au-qld');
+
+    expect(capability).toMatchObject({
+      providerId: fixture.providerId,
+      releaseChannel: 'planned',
+      sourceAuthority: 'Queensland Legislation API service',
+    });
+    expect(card).toMatchObject({
+      runtimeSupported: false,
+      runtimeKind: 'planned-au-provider',
+      releaseGate: { status: 'blocked' },
+      submissionGate: { status: 'blocked' },
+    });
+    for (const feature of Object.values(card.sourceBackedFeatureSummary.features)) {
+      expect(feature).toMatchObject({ status: 'unsupported', sourceBacked: false });
+    }
+  });
+});


### PR DESCRIPTION
## Summary\n- add official Queensland API source-shape metadata and access boundaries\n- add metadata-only readiness fixtures/tests with explicit planned/unsupported runtime posture\n- advance Conductor Queensland track discovery checklist\n\nCloses #52