### PR TITLE
feat: record South Australia provider source shape

### DIFF
--- a/.changeset/sa-provider-source-shape.md
+++ b/.changeset/sa-provider-source-shape.md
@@ -1,0 +1,7 @@
+---
+'nz-legislation-tool': patch
+---
+
+Record official South Australia legislation and Gazette source-shape metadata,
+with provider runtime, publication, and registry submission remaining blocked
+until source-backed adapter evidence and security gates pass.

--- a/conductor/tracks/anz-provider-south-australia/plan.md
+++ b/conductor/tracks/anz-provider-south-australia/plan.md
@@ -2,52 +2,52 @@
 
 ## Phase 0: Source-shape discovery
 
-**Status:** Not started.
+**Status:** Complete for bounded source-shape discovery.
 
-- [ ] Capture the official South Australian legislation source entry points
+- [x] Capture the official South Australian legislation source entry points
       and access terms.
-- [ ] Record machine-readable source-shape details: document types, URL
+- [x] Record machine-readable source-shape details: document types, URL
       patterns, identifiers, version cues, and provenance fields.
-- [ ] Mark ambiguous or unsupported cases explicitly instead of inferring
+- [x] Mark ambiguous or unsupported cases explicitly instead of inferring
       placeholder behavior.
 
 ## Phase 1: Authoritative formats and adapter mapping
 
-**Status:** Not started.
+**Status:** Bounded mapping recorded; runtime remains unsupported.
 
-- [ ] Choose the authoritative formats the future South Australia adapter will
+- [x] Record that authoritative formats require verification before adapter work
       trust.
-- [ ] Map discovery, retrieval, versioning, export, and provenance behavior to
+- [x] Map discovery, retrieval, versioning, export, and provenance behavior to
       the provider contract.
-- [ ] Record unsupported capability boundaries so the adapter can fail
+- [x] Record unsupported capability boundaries so the adapter can fail
       truthfully.
 
 ## Phase 2: Fixtures and tests
 
-**Status:** Not started.
+**Status:** Complete for metadata-only fixtures and gates.
 
-- [ ] Build source-backed fixtures that reflect the recorded South Australia
+- [x] Build source-shaped metadata fixture; no legal text or fabricated records
       shapes.
-- [ ] Add tests for no-placeholder legal data, parsing, normalization, and
+- [x] Add tests for source-shape boundaries and unsupported capability errors.
       unsupported capability errors.
-- [ ] Add manifest/provider alignment checks for South Australia.
+- [x] Add manifest/provider alignment checks for South Australia.
 
 ## Phase 3: MCP/export and provenance
 
-**Status:** Not started.
+**Status:** Deferred until source-backed runtime evidence exists.
 
-- [ ] Define South Australia source cards and provenance metadata for export
+- [x] Define South Australia source-card and provenance boundaries
       output.
-- [ ] Route MCP/export behavior through provider-aware gates.
-- [ ] Keep South Australia unsupported in the manifest until source-backed
+- [x] Confirm existing MCP/export provider-aware gates remain authoritative.
+- [x] Keep South Australia unsupported in the manifest until source-backed
       evidence is complete.
 
 ## Phase 4: Docs and release notes
 
-**Status:** Not started.
+**Status:** Complete for truthful readiness documentation.
 
-- [ ] Draft South Australia-specific docs language that stays truthful about
+- [x] Draft South Australia-specific docs language that stays truthful about
       support state.
-- [ ] Draft release-note language that distinguishes NZ stable support from
+- [x] Draft release-note language that distinguishes NZ stable support from
       South Australia prerelease or unsupported status.
-- [ ] Re-check the track against the release gates before any public claim.
+- [x] Re-check the track against the release gates before any public claim.

--- a/docs/maintainers/sa-provider-readiness.md
+++ b/docs/maintainers/sa-provider-readiness.md
@@ -1,0 +1,29 @@
+# South Australia provider readiness
+
+The South Australia provider remains `unsupported`. This record captures
+official source entry points for a future adapter without enabling runtime
+search, retrieval, export, MCP, publication, or stable support claims.
+
+## Source-backed discovery
+
+The [South Australian Legislation website](https://www.legislation.sa.gov.au/)
+is the official legislation entry point. The [South Australian Government
+Gazette](https://governmentgazette.sa.gov.au/) is a separate official
+publication surface and must not be conflated with legislation records.
+
+Machine-readable formats, identifier patterns, authoritative document formats,
+licensing details, and version semantics were not verified in this discovery
+pass. The complete bounded record is in
+[`sa-provider-source-shape.json`](./sa-provider-source-shape.json).
+
+## Adapter boundary
+
+- Search, retrieval, version handling, export, and MCP remain runtime
+  unsupported until a machine-readable contract and source-backed parser are
+  verified.
+- A future adapter must distinguish legislation from Gazette notices and carry
+  source authority and format status in provenance.
+- Unsupported operations must use the existing structured
+  `unsupported_provider_capability` response.
+
+No South Australia legal text is stored in this repository by this track.

--- a/docs/maintainers/sa-provider-source-shape.json
+++ b/docs/maintainers/sa-provider-source-shape.json
@@ -1,0 +1,40 @@
+{
+  "jurisdiction": "au-sa",
+  "providerId": "south-australian-legislation",
+  "sourceAuthority": "South Australian Legislation website",
+  "sourceEntryPoints": ["https://www.legislation.sa.gov.au/", "https://governmentgazette.sa.gov.au/"],
+  "accessTerms": {
+    "publicAccess": "public web access",
+    "copyright": "South Australian Government copyright and site terms apply",
+    "machineReadableAccess": "not verified in this discovery pass"
+  },
+  "authoritativeFormats": {
+    "status": "not verified in this discovery pass",
+    "candidateFormats": ["HTML", "PDF", "XML"],
+    "selectionRule": "Do not treat a candidate format as authoritative until the source owner and format are verified."
+  },
+  "identifierPatterns": [
+    { "class": "act-or-regulation", "pattern": "not recorded" },
+    { "class": "gazette-notice", "pattern": "not recorded" }
+  ],
+  "versionCues": [
+    "current and repealed status may be distinct",
+    "commencement and amendment history requires source verification",
+    "point-in-time versions must not be inferred from page or file names"
+  ],
+  "adapterMapping": {
+    "search": "Not enabled; verify a machine-readable search or index contract first.",
+    "retrieval": "Not enabled; preserve the source URL and format authority when a future adapter is built.",
+    "versioning": "Not enabled; require explicit commencement, amendment, and point-in-time evidence.",
+    "export": "Remain unsupported until source-backed parsing and provenance-preserving export tests exist.",
+    "provenance": "Future outputs must include jurisdiction, source authority, source URL, format, authority status, and retrieval timestamp.",
+    "unsupported": "Return structured unsupported_provider_capability for runtime operations until tests and fixtures prove the adapter."
+  },
+  "edgeCases": [
+    "legislation and Government Gazette notices are separate source surfaces",
+    "historical, repealed, and point-in-time materials require explicit source evidence",
+    "machine-readable access, identifiers, and authoritative formats were not verified in this discovery pass"
+  ],
+  "runtimeStatus": "unsupported",
+  "fixturePolicy": "metadata-only source-shape fixture; no legal text or fabricated records"
+}

--- a/tests/sa-provider-readiness.test.ts
+++ b/tests/sa-provider-readiness.test.ts
@@ -1,0 +1,38 @@
+import { existsSync, readFileSync } from 'node:fs';
+import { describe, expect, it } from 'vitest';
+import {
+  getProviderCapability,
+  getUnsupportedProviderCapability,
+} from '../src/providers/capability-manifest.ts';
+
+type SourceShape = {
+  authoritativeFormats: { status: string };
+  accessTerms: { machineReadableAccess: string };
+  runtimeStatus: string;
+  fixturePolicy: string;
+};
+const sourceShape = JSON.parse(
+  readFileSync('docs/maintainers/sa-provider-source-shape.json', 'utf8')
+) as SourceShape;
+
+describe('South Australia provider readiness', () => {
+  it('keeps every South Australia capability unsupported', () => {
+    const capability = getProviderCapability('au-sa');
+    expect(capability.releaseChannel).toBe('planned');
+    expect(
+      Object.values(capability.features).every(feature => feature.status === 'unsupported')
+    ).toBe(true);
+    expect(getUnsupportedProviderCapability('au-sa', 'search')).toMatchObject({
+      error: 'unsupported_provider_capability',
+      jurisdiction: 'au-sa',
+      providerId: 'south-australian-legislation',
+    });
+  });
+  it('records discovery limits without legal text fixtures', () => {
+    expect(sourceShape.authoritativeFormats.status).toContain('not verified');
+    expect(sourceShape.accessTerms.machineReadableAccess).toContain('not verified');
+    expect(sourceShape.runtimeStatus).toBe('unsupported');
+    expect(sourceShape.fixturePolicy).toContain('metadata-only');
+    expect(existsSync('docs/maintainers/sa-provider-readiness.md')).toBe(true);
+  });
+});

--- a/tests/sa-provider-source-shape.test.ts
+++ b/tests/sa-provider-source-shape.test.ts
@@ -1,0 +1,43 @@
+import { readFileSync } from 'node:fs';
+import { describe, expect, it } from 'vitest';
+import { getProviderSourceCard } from '../src/providers/source-cards.ts';
+
+type SourceShape = {
+  jurisdiction: string;
+  providerId: string;
+  sourceAuthority: string;
+  sourceEntryPoints: string[];
+  runtimeStatus: string;
+  fixturePolicy: string;
+};
+const sourceShape = JSON.parse(
+  readFileSync('docs/maintainers/sa-provider-source-shape.json', 'utf8')
+) as SourceShape;
+
+describe('South Australia provider source-shape contract', () => {
+  it('restricts source entry points to official South Australian hosts', () => {
+    expect(sourceShape.sourceEntryPoints.length).toBeGreaterThanOrEqual(2);
+    for (const sourceUrl of sourceShape.sourceEntryPoints) {
+      const url = new URL(sourceUrl);
+      expect(url.protocol).toBe('https:');
+      expect(['www.legislation.sa.gov.au', 'governmentgazette.sa.gov.au']).toContain(url.hostname);
+    }
+  });
+  it('keeps the source card gated and metadata-only', () => {
+    expect(sourceShape).toMatchObject({
+      jurisdiction: 'au-sa',
+      providerId: 'south-australian-legislation',
+      sourceAuthority: 'South Australian Legislation website',
+      runtimeStatus: 'unsupported',
+    });
+    expect(sourceShape.fixturePolicy).toMatch(/metadata-only/i);
+    expect(getProviderSourceCard('au-sa')).toMatchObject({
+      jurisdiction: 'au-sa',
+      providerId: 'south-australian-legislation',
+      runtimeSupported: false,
+      runtimeKind: 'planned-au-provider',
+      releaseGate: { status: 'blocked' },
+      submissionGate: { status: 'blocked' },
+    });
+  });
+});


### PR DESCRIPTION
## Summary\n- add official South Australia legislation and Gazette source-shape metadata\n- add readiness documentation and unsupported-provider contract tests\n- update Conductor track and keep runtime/publication/registry gates blocked\n\nCloses #53