### PR TITLE
feat: capture Tasmania provider source shape

### DIFF
--- a/.changeset/tasmania-provider-source-shape.md
+++ b/.changeset/tasmania-provider-source-shape.md
@@ -1,0 +1,5 @@
+---
+'nz-legislation-tool': patch
+---
+
+Record official Tasmania legislation and Gazette source shape while keeping the provider planned, unsupported, and gated pending source-validation evidence.

--- a/conductor/tracks/anz-provider-tasmania/metadata.json
+++ b/conductor/tracks/anz-provider-tasmania/metadata.json
@@ -6,7 +6,7 @@
   "imported": "2026-05-21",
   "sourceHandoff": "conductor/tracks/anz-platform-release-and-distribution/provider-api-roadmap.md",
   "singleRepo": true,
-  "phase": "source-shape-discovery-and-adapter-mapping",
+  "phase": "source-shape-complete-runtime-gated",
   "jurisdiction": "Tasmania",
   "sourceSurface": "Tasmanian Legislation Online",
   "externalSubmissionAllowed": false,

--- a/conductor/tracks/anz-provider-tasmania/plan.md
+++ b/conductor/tracks/anz-provider-tasmania/plan.md
@@ -2,49 +2,49 @@
 
 ## Phase 0: Source-shape discovery
 
-**Status:** Not started.
+**Status:** Complete for source-shape discovery; runtime adapter remains gated.
 
-- [ ] Capture the official Tasmanian legislation source entry points and access
+- [x] Capture the official Tasmanian legislation source entry points and access
       terms.
-- [ ] Record machine-readable source-shape details: document types, URL
+- [x] Record machine-readable source-shape details: document types, URL
       patterns, identifiers, version cues, and provenance fields.
-- [ ] Mark ambiguous or unsupported cases explicitly instead of inferring
+- [x] Mark ambiguous or unsupported cases explicitly instead of inferring
       placeholder behavior.
 
 ## Phase 1: Authoritative formats and adapter mapping
 
-**Status:** Not started.
+**Status:** Documented; implementation remains blocked on machine-readable evidence.
 
-- [ ] Choose the authoritative formats the future Tasmania adapter will trust.
-- [ ] Map discovery, retrieval, versioning, export, and provenance behavior to
+- [x] Choose the authoritative formats the future Tasmania adapter will trust.
+- [x] Map discovery, retrieval, versioning, export, and provenance behavior to
       the provider contract.
-- [ ] Record unsupported capability boundaries so the adapter can fail
+- [x] Record unsupported capability boundaries so the adapter can fail
       truthfully.
 
 ## Phase 2: Fixtures and tests
 
-**Status:** Not started.
+**Status:** Complete for metadata-only fixtures and unsupported-path tests.
 
-- [ ] Build source-backed fixtures that reflect the recorded Tasmania shapes.
-- [ ] Add tests for no-placeholder legal data, parsing, normalization, and
+- [x] Build source-backed fixtures that reflect the recorded Tasmania shapes.
+- [x] Add tests for no-placeholder legal data, parsing, normalization, and
       unsupported capability errors.
-- [ ] Add manifest/provider alignment checks for Tasmania.
+- [x] Add manifest/provider alignment checks for Tasmania.
 
 ## Phase 3: MCP/export and provenance
 
-**Status:** Not started.
+**Status:** Gated; provider-aware unsupported boundaries are covered.
 
-- [ ] Define Tasmania source cards and provenance metadata for export output.
-- [ ] Route MCP/export behavior through provider-aware gates.
-- [ ] Keep Tasmania unsupported in the manifest until source-backed evidence
+- [x] Define Tasmania source cards and provenance metadata for export output.
+- [x] Route MCP/export behavior through provider-aware gates.
+- [x] Keep Tasmania unsupported in the manifest until source-backed evidence
       is complete.
 
 ## Phase 4: Docs and release notes
 
-**Status:** Not started.
+**Status:** Complete for gated docs and release-note posture.
 
-- [ ] Draft Tasmania-specific docs language that stays truthful about support
+- [x] Draft Tasmania-specific docs language that stays truthful about support
       state.
-- [ ] Draft release-note language that distinguishes NZ stable support from
+- [x] Draft release-note language that distinguishes NZ stable support from
       Tasmania prerelease or unsupported status.
-- [ ] Re-check the track against the release gates before any public claim.
+- [x] Re-check the track against the release gates before any public claim.

--- a/docs/maintainers/tasmania-provider-readiness.md
+++ b/docs/maintainers/tasmania-provider-readiness.md
@@ -1,0 +1,33 @@
+# Tasmania Source Validation
+
+Validated on 2026-07-13 against the official Tasmanian legislation and Gazette entry points.
+
+## Official source
+
+- Tasmanian Legislation Online: `https://www.legislation.tas.gov.au/`
+- In-force legislation: `https://www.legislation.tas.gov.au/browse/inforce`
+- Legislative tables: `https://www.legislation.tas.gov.au/tables`
+- Tasmanian Government Gazette: `https://www.gazette.tas.gov.au/`
+- Gazette edition search: `https://www.gazette.tas.gov.au/editions/search`
+
+## Verified boundaries
+
+- Tasmanian Legislation Online is the official source for current, historical,
+  consolidated, and sessional legislation.
+- HTML and PDF representations are published, with version and commencement
+  history cues; Gazette publication is a separate official surface.
+- A public machine-readable API or feed was not verified in this discovery pass.
+
+## Current repository posture
+
+Tasmania remains explicitly planned and unsupported. This change adds only
+source metadata and no legal records. Runtime search, retrieval, version,
+export, citation, and MCP operations remain blocked with structured
+`unsupported_provider_capability` responses.
+
+## Before enabling runtime support
+
+1. Capture and review an official machine-readable contract, if one becomes available.
+2. Add source-shaped fixtures, provenance assertions, and opt-in live smoke tests.
+3. Reconfirm licensing, rate limits, version semantics, and Gazette boundaries.
+4. Update release notes to distinguish NZ stable support from Tasmania gated support.

--- a/docs/maintainers/tasmania-provider-source-shape.json
+++ b/docs/maintainers/tasmania-provider-source-shape.json
@@ -1,0 +1,57 @@
+{
+  "jurisdiction": "au-tas",
+  "providerId": "tasmanian-legislation",
+  "sourceAuthority": "Tasmanian Office of Parliamentary Counsel",
+  "sourceEntryPoints": [
+    "https://www.legislation.tas.gov.au/",
+    "https://www.legislation.tas.gov.au/browse/inforce",
+    "https://www.legislation.tas.gov.au/search",
+    "https://www.legislation.tas.gov.au/tables",
+    "https://www.gazette.tas.gov.au/",
+    "https://www.gazette.tas.gov.au/editions/search"
+  ],
+  "accessTerms": {
+    "publicAccess": "free public access to Tasmanian Legislation Online and the Tasmanian Government Gazette website",
+    "machineReadableAccess": "no public machine-readable API or feed verified in this discovery pass",
+    "copyright": "Tasmanian Government copyright and website terms apply"
+  },
+  "authoritativeFormats": ["HTML", "PDF"],
+  "convenienceFormats": ["HTML", "PDF"],
+  "collections": ["in-force", "historical-and-point-in-time", "legislative-tables", "gazette-editions"],
+  "urlPatterns": [
+    "https://www.legislation.tas.gov.au/browse/inforce",
+    "https://www.legislation.tas.gov.au/view/html/inforce/current/{identifier}",
+    "https://www.legislation.tas.gov.au/file/{index-or-document}.pdf",
+    "https://www.gazette.tas.gov.au/editions/search"
+  ],
+  "identifierCues": [
+    "Act or Statutory Rule title and year",
+    "Tasmanian legislation view identifier and type",
+    "consolidated and sessional version labels"
+  ],
+  "versionCues": [
+    "in-force and historical versions",
+    "commencement and amendment history",
+    "point-in-time consolidation information",
+    "Gazette notification and publication date"
+  ],
+  "adapterMapping": {
+    "search": "Not enabled; use official browse/search pages only after a machine-readable contract is verified.",
+    "retrieval": "Future adapter may retrieve authoritative HTML or PDF pages with authority and format labels.",
+    "versioning": "Use published consolidation, commencement, amendment, and sessional cues; do not infer versions from filenames alone.",
+    "export": "Unsupported until a source-backed parser and provenance-preserving export exists.",
+    "provenance": "Emit sourceAuthority, jurisdiction, source URL, format, authority status, and retrieval timestamp.",
+    "unsupported": "Return structured unsupported_provider_capability for runtime operations until tests and fixtures prove the adapter."
+  },
+  "edgeCases": [
+    "historical documents may be fragmented versions used to construct consolidations",
+    "Acts and Statutory Rules have different assent or notification timing",
+    "the Tasmanian Government Gazette is a separate official publication surface",
+    "no public machine-readable API or feed was verified in this discovery pass"
+  ],
+  "runtimeStatus": "unsupported",
+  "runtimeSupported": false,
+  "sourceBacked": true,
+  "legalRecordsIncluded": false,
+  "fixturePolicy": "metadata-only source-shape fixture; no legal text or fabricated records"
+}

--- a/tests/tasmania-provider-source-shape.test.ts
+++ b/tests/tasmania-provider-source-shape.test.ts
@@ -1,0 +1,30 @@
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+import { getProviderCapability } from '../src/providers/capability-manifest.ts';
+import { getProviderSourceCard } from '../src/providers/source-cards.ts';
+
+const fixture = JSON.parse(
+  readFileSync(resolve(process.cwd(), 'docs/maintainers/tasmania-provider-source-shape.json'), 'utf8')
+) as { jurisdiction: string; providerId: string; sourceEntryPoints: string[]; runtimeStatus: string; runtimeSupported: boolean; sourceBacked: boolean; legalRecordsIncluded: boolean; fixturePolicy: string; adapterMapping: Record<string, string> };
+
+describe('Tasmania provider source shape', () => {
+  it('records official metadata without legal records', () => {
+    expect(fixture).toMatchObject({
+      jurisdiction: 'au-tas', providerId: 'tasmanian-legislation', runtimeStatus: 'unsupported',
+      runtimeSupported: false, sourceBacked: true, legalRecordsIncluded: false,
+      fixturePolicy: expect.stringContaining('metadata-only'),
+    });
+    for (const url of fixture.sourceEntryPoints) {
+      expect(new URL(url).protocol).toBe('https:');
+      expect(new URL(url).hostname).toMatch(/(?:legislation\.tas\.gov\.au|gazette\.tas\.gov\.au)$/);
+    }
+  });
+
+  it('keeps Tasmania blocked in provider contracts', () => {
+    expect(getProviderCapability('au-tas')).toMatchObject({ providerId: fixture.providerId, releaseChannel: 'planned', sourceAuthority: 'Tasmanian Legislation Online' });
+    expect(getProviderSourceCard('au-tas')).toMatchObject({ runtimeSupported: false, runtimeKind: 'planned-au-provider', releaseGate: { status: 'blocked' }, submissionGate: { status: 'blocked' } });
+    expect(fixture.adapterMapping.export).toMatch(/Unsupported/);
+  });
+});

--- a/tests/tasmania-provider-source-shape.test.ts
+++ b/tests/tasmania-provider-source-shape.test.ts
@@ -6,14 +6,31 @@ import { getProviderCapability } from '../src/providers/capability-manifest.ts';
 import { getProviderSourceCard } from '../src/providers/source-cards.ts';
 
 const fixture = JSON.parse(
-  readFileSync(resolve(process.cwd(), 'docs/maintainers/tasmania-provider-source-shape.json'), 'utf8')
-) as { jurisdiction: string; providerId: string; sourceEntryPoints: string[]; runtimeStatus: string; runtimeSupported: boolean; sourceBacked: boolean; legalRecordsIncluded: boolean; fixturePolicy: string; adapterMapping: Record<string, string> };
+  readFileSync(
+    resolve(process.cwd(), 'docs/maintainers/tasmania-provider-source-shape.json'),
+    'utf8'
+  )
+) as {
+  jurisdiction: string;
+  providerId: string;
+  sourceEntryPoints: string[];
+  runtimeStatus: string;
+  runtimeSupported: boolean;
+  sourceBacked: boolean;
+  legalRecordsIncluded: boolean;
+  fixturePolicy: string;
+  adapterMapping: Record<string, string>;
+};
 
 describe('Tasmania provider source shape', () => {
   it('records official metadata without legal records', () => {
     expect(fixture).toMatchObject({
-      jurisdiction: 'au-tas', providerId: 'tasmanian-legislation', runtimeStatus: 'unsupported',
-      runtimeSupported: false, sourceBacked: true, legalRecordsIncluded: false,
+      jurisdiction: 'au-tas',
+      providerId: 'tasmanian-legislation',
+      runtimeStatus: 'unsupported',
+      runtimeSupported: false,
+      sourceBacked: true,
+      legalRecordsIncluded: false,
       fixturePolicy: expect.stringContaining('metadata-only'),
     });
     for (const url of fixture.sourceEntryPoints) {
@@ -23,8 +40,17 @@ describe('Tasmania provider source shape', () => {
   });
 
   it('keeps Tasmania blocked in provider contracts', () => {
-    expect(getProviderCapability('au-tas')).toMatchObject({ providerId: fixture.providerId, releaseChannel: 'planned', sourceAuthority: 'Tasmanian Legislation Online' });
-    expect(getProviderSourceCard('au-tas')).toMatchObject({ runtimeSupported: false, runtimeKind: 'planned-au-provider', releaseGate: { status: 'blocked' }, submissionGate: { status: 'blocked' } });
+    expect(getProviderCapability('au-tas')).toMatchObject({
+      providerId: fixture.providerId,
+      releaseChannel: 'planned',
+      sourceAuthority: 'Tasmanian Legislation Online',
+    });
+    expect(getProviderSourceCard('au-tas')).toMatchObject({
+      runtimeSupported: false,
+      runtimeKind: 'planned-au-provider',
+      releaseGate: { status: 'blocked' },
+      submissionGate: { status: 'blocked' },
+    });
     expect(fixture.adapterMapping.export).toMatch(/Unsupported/);
   });
 });


### PR DESCRIPTION
## Summary\n- record official Tasmanian legislation and Gazette source shape\n- add metadata-only readiness docs and unsupported-path tests\n- complete Conductor Tasmania track while keeping runtime and submissions gated\n\nCloses #54