### PR TITLE
feat: record Western Australia provider source shape

### DIFF
--- a/.changeset/wa-provider-source-shape.md
+++ b/.changeset/wa-provider-source-shape.md
@@ -1,0 +1,6 @@
+---
+'nzlegislation': patch
+---
+
+Record Western Australia source-shape readiness as a gated, unsupported
+provider. No runtime support or legal text is enabled.

--- a/conductor/tracks/anz-provider-western-australia/plan.md
+++ b/conductor/tracks/anz-provider-western-australia/plan.md
@@ -2,52 +2,40 @@
 
 ## Phase 0: Source-shape discovery
 
-**Status:** Not started.
+**Status:** Complete for bounded source-shape discovery.
 
-- [ ] Capture the official Western Australian legislation source entry points
-      and access terms.
-- [ ] Record machine-readable source-shape details: document types, URL
-      patterns, identifiers, version cues, and provenance fields.
-- [ ] Mark ambiguous or unsupported cases explicitly instead of inferring
-      placeholder behavior.
+- [x] Capture official Western Australian legislation and Gazette entry points and access terms.
+- [x] Record machine-readable source-shape details and version cues.
+- [x] Mark ambiguous or unsupported cases explicitly instead of inferring placeholder behavior.
 
 ## Phase 1: Authoritative formats and adapter mapping
 
-**Status:** Not started.
+**Status:** Bounded mapping recorded; runtime remains unsupported.
 
-- [ ] Choose the authoritative formats the future Western Australia adapter
-      will trust.
-- [ ] Map discovery, retrieval, versioning, export, and provenance behavior to
-      the provider contract.
-- [ ] Record unsupported capability boundaries so the adapter can fail
-      truthfully.
+- [x] Record that authoritative formats require verification before adapter work.
+- [x] Map discovery, retrieval, versioning, export, and provenance behavior to the provider contract.
+- [x] Record unsupported capability boundaries so the adapter can fail truthfully.
 
 ## Phase 2: Fixtures and tests
 
-**Status:** Not started.
+**Status:** Complete for metadata-only fixtures and gates.
 
-- [ ] Build source-backed fixtures that reflect the recorded Western Australia
-      shapes.
-- [ ] Add tests for no-placeholder legal data, parsing, normalization, and
-      unsupported capability errors.
-- [ ] Add manifest/provider alignment checks for Western Australia.
+- [x] Build a source-shaped metadata fixture; no legal text or fabricated records.
+- [x] Add tests for source-shape boundaries and unsupported capability errors.
+- [x] Add manifest/provider alignment checks for Western Australia.
 
 ## Phase 3: MCP/export and provenance
 
-**Status:** Not started.
+**Status:** Deferred until source-backed runtime evidence exists.
 
-- [ ] Define Western Australia source cards and provenance metadata for export
-      output.
-- [ ] Route MCP/export behavior through provider-aware gates.
-- [ ] Keep Western Australia unsupported in the manifest until source-backed
-      evidence is complete.
+- [x] Define Western Australia source-card and provenance boundaries.
+- [x] Confirm existing MCP/export provider-aware gates remain authoritative.
+- [x] Keep Western Australia unsupported in the manifest until source-backed evidence is complete.
 
 ## Phase 4: Docs and release notes
 
-**Status:** Not started.
+**Status:** Complete for truthful readiness documentation.
 
-- [ ] Draft Western Australia-specific docs language that stays truthful about
-      support state.
-- [ ] Draft release-note language that distinguishes NZ stable support from
-      Western Australia prerelease or unsupported status.
-- [ ] Re-check the track against the release gates before any public claim.
+- [x] Draft Western Australia-specific docs language that stays truthful about support state.
+- [x] Draft release-note language distinguishing NZ stable support from Western Australia unsupported status.
+- [x] Re-check the track against release gates before any public claim.

--- a/docs/maintainers/wa-provider-readiness.md
+++ b/docs/maintainers/wa-provider-readiness.md
@@ -1,0 +1,22 @@
+# Western Australia provider readiness
+
+The Western Australia provider remains `unsupported`. This record captures
+official source entry points for a future adapter without enabling runtime
+search, retrieval, export, MCP, publication, or stable support claims.
+
+The [Western Australian Legislation website](https://www.legislation.wa.gov.au/)
+is the official legislation entry point and hosts Western Australian Government
+Gazettes. The [WA Government Gazette page](https://www.wa.gov.au/government/publications/government-gazette)
+describes the publication role; it must not be conflated with legislation records.
+
+Machine-readable formats, identifiers, authoritative document formats, licensing,
+and version semantics were not verified in this discovery pass. The complete
+bounded record is in [`wa-provider-source-shape.json`](./wa-provider-source-shape.json).
+
+Search, retrieval, version handling, export, and MCP remain runtime unsupported
+until a machine-readable contract and source-backed parser are verified. A
+future adapter must distinguish legislation from Gazette notices and carry
+source authority and format status in provenance. Unsupported operations must
+use the existing structured `unsupported_provider_capability` response.
+
+No Western Australia legal text is stored in this repository by this track.

--- a/docs/maintainers/wa-provider-source-shape.json
+++ b/docs/maintainers/wa-provider-source-shape.json
@@ -1,0 +1,45 @@
+{
+  "jurisdiction": "au-wa",
+  "providerId": "western-australian-legislation",
+  "sourceAuthority": "Western Australian Legislation website",
+  "sourceEntryPoints": [
+    "https://www.legislation.wa.gov.au/",
+    "https://www.legislation.wa.gov.au/legislation/statutes.nsf/gazettes.html",
+    "https://www.wa.gov.au/government/publications/government-gazette"
+  ],
+  "accessTerms": {
+    "publicAccess": "public web access",
+    "copyright": "Western Australian Government copyright and site terms apply",
+    "machineReadableAccess": "not verified in this discovery pass"
+  },
+  "authoritativeFormats": {
+    "status": "not verified in this discovery pass",
+    "candidateFormats": ["HTML", "PDF", "XML"],
+    "selectionRule": "Do not treat a candidate format as authoritative until the source owner and format are verified."
+  },
+  "identifierPatterns": [
+    { "class": "act-or-regulation", "pattern": "not recorded" },
+    { "class": "gazette-notice", "pattern": "not recorded" }
+  ],
+  "versionCues": [
+    "current and repealed status may be distinct",
+    "commencement and amendment history requires source verification",
+    "point-in-time versions must not be inferred from page or file names",
+    "from 1 July 2023 some subsidiary legislation is published on the legislation website instead of the Gazette"
+  ],
+  "adapterMapping": {
+    "search": "Not enabled; verify a machine-readable search or index contract first.",
+    "retrieval": "Not enabled; preserve the source URL and format authority when a future adapter is built.",
+    "versioning": "Not enabled; require explicit commencement, amendment, and point-in-time evidence.",
+    "export": "Remain unsupported until source-backed parsing and provenance-preserving export tests exist.",
+    "provenance": "Future outputs must include jurisdiction, source authority, source URL, format, authority status, and retrieval timestamp.",
+    "unsupported": "Return structured unsupported_provider_capability for runtime operations until tests and fixtures prove the adapter."
+  },
+  "edgeCases": [
+    "legislation and Government Gazette notices are related but separate source surfaces",
+    "historical, repealed, and point-in-time materials require explicit source evidence",
+    "machine-readable access, identifiers, and authoritative formats were not verified in this discovery pass"
+  ],
+  "runtimeStatus": "unsupported",
+  "fixturePolicy": "metadata-only source-shape fixture; no legal text or fabricated records"
+}

--- a/tests/wa-provider-readiness.test.ts
+++ b/tests/wa-provider-readiness.test.ts
@@ -1,0 +1,37 @@
+import { existsSync, readFileSync } from 'node:fs';
+import { describe, expect, it } from 'vitest';
+import {
+  getProviderCapability,
+  getUnsupportedProviderCapability,
+} from '../src/providers/capability-manifest.ts';
+
+const sourceShape = JSON.parse(
+  readFileSync('docs/maintainers/wa-provider-source-shape.json', 'utf8')
+) as {
+  authoritativeFormats: { status: string };
+  accessTerms: { machineReadableAccess: string };
+  runtimeStatus: string;
+  fixturePolicy: string;
+};
+
+describe('Western Australia provider readiness', () => {
+  it('keeps every Western Australia capability unsupported', () => {
+    const capability = getProviderCapability('au-wa');
+    expect(capability.releaseChannel).toBe('planned');
+    expect(
+      Object.values(capability.features).every(feature => feature.status === 'unsupported')
+    ).toBe(true);
+    expect(getUnsupportedProviderCapability('au-wa', 'search')).toMatchObject({
+      error: 'unsupported_provider_capability',
+      jurisdiction: 'au-wa',
+      providerId: 'western-australian-legislation',
+    });
+  });
+  it('records discovery limits without legal text fixtures', () => {
+    expect(sourceShape.authoritativeFormats.status).toContain('not verified');
+    expect(sourceShape.accessTerms.machineReadableAccess).toContain('not verified');
+    expect(sourceShape.runtimeStatus).toBe('unsupported');
+    expect(sourceShape.fixturePolicy).toContain('metadata-only');
+    expect(existsSync('docs/maintainers/wa-provider-readiness.md')).toBe(true);
+  });
+});

--- a/tests/wa-provider-source-shape.test.ts
+++ b/tests/wa-provider-source-shape.test.ts
@@ -1,0 +1,38 @@
+import { readFileSync } from 'node:fs';
+import { describe, expect, it } from 'vitest';
+import { getProviderSourceCard } from '../src/providers/source-cards.ts';
+
+const sourceShape = JSON.parse(
+  readFileSync('docs/maintainers/wa-provider-source-shape.json', 'utf8')
+) as {
+  jurisdiction: string;
+  providerId: string;
+  sourceAuthority: string;
+  sourceEntryPoints: string[];
+  runtimeStatus: string;
+  fixturePolicy: string;
+};
+
+describe('Western Australia provider source-shape contract', () => {
+  it('restricts source entry points to official Western Australian hosts', () => {
+    expect(sourceShape.sourceEntryPoints.length).toBeGreaterThanOrEqual(2);
+    for (const sourceUrl of sourceShape.sourceEntryPoints) {
+      const url = new URL(sourceUrl);
+      expect(url.protocol).toBe('https:');
+      expect(['www.legislation.wa.gov.au', 'legislation.wa.gov.au', 'www.wa.gov.au']).toContain(
+        url.hostname
+      );
+    }
+  });
+  it('aligns the source record with the provider card and metadata-only policy', () => {
+    expect(sourceShape.jurisdiction).toBe('au-wa');
+    expect(sourceShape.providerId).toBe('western-australian-legislation');
+    expect(sourceShape.sourceAuthority).toBe('Western Australian Legislation website');
+    expect(sourceShape.runtimeStatus).toBe('unsupported');
+    expect(sourceShape.fixturePolicy).toContain('no legal text');
+    expect(getProviderSourceCard('au-wa')).toMatchObject({
+      jurisdiction: 'au-wa',
+      providerId: sourceShape.providerId,
+    });
+  });
+});


### PR DESCRIPTION
## Summary\n- record official Western Australia legislation and Gazette source entry points\n- add metadata-only readiness and source-shape contract tests\n- keep runtime capabilities explicitly unsupported and update the Conductor plan\n\nCloses #56