### PR TITLE
docs: evaluate aggregator provider provenance

### DIFF
--- a/.changeset/aggregator-provider-evaluation.md
+++ b/.changeset/aggregator-provider-evaluation.md
@@ -1,0 +1,5 @@
+---
+'nz-legislation-tool': patch
+---
+
+Record source, provenance, licence, and attribution constraints for AustLII and NZLII as evaluation-only discovery candidates; runtime support and redistribution remain blocked.

--- a/conductor/tracks/anz-provider-aggregator-evaluation/plan.md
+++ b/conductor/tracks/anz-provider-aggregator-evaluation/plan.md
@@ -6,8 +6,10 @@
 
 - [x] Add aggregator evaluation to the requirements contract register.
 - [x] Add this Conductor track for the roadmap entry.
-- [ ] Identify candidate aggregators and licence/provenance constraints.
-- [ ] Decide whether any candidate can support non-runtime discovery work.
+- [x] Identify candidate aggregators and licence/provenance constraints in the
+      maintainer evaluation register.
+- [x] Decide that candidates remain evaluation-only discovery aids; no runtime
+      route or redistribution is enabled.
 
 ## Phase 2: Runtime decision
 
@@ -16,3 +18,8 @@
 - [ ] Add provider capability status only after an explicit source and licence
       review.
 - [ ] Add tests before any runtime route is enabled.
+
+Evidence: `docs/maintainers/aggregator-provider-evaluation.json` and
+`tests/aggregator-provider-evaluation.test.ts` record AustLII and NZLII source,
+provenance, licence, freshness, and attribution constraints without legal
+records or runtime capability.

--- a/docs/maintainers/aggregator-provider-evaluation.json
+++ b/docs/maintainers/aggregator-provider-evaluation.json
@@ -1,0 +1,73 @@
+{
+  "version": "1.0.0",
+  "policy": {
+    "officialSourceFirst": true,
+    "runtimeEnabled": false,
+    "legalRecordsIncluded": false,
+    "submissionAllowed": false,
+    "attributionRequired": true,
+    "licenceReviewRequired": true
+  },
+  "candidates": [
+    {
+      "providerId": "austlii",
+      "name": "Australasian Legal Information Institute",
+      "jurisdictions": [
+        "nz",
+        "au-commonwealth",
+        "au-act",
+        "au-nsw",
+        "au-nt",
+        "au-qld",
+        "au-sa",
+        "au-tas",
+        "au-vic",
+        "au-wa"
+      ],
+      "sourceUrls": [
+        "https://www.austlii.edu.au/",
+        "https://www5.austlii.edu.au/austlii/help/legis.html",
+        "https://www5.austlii.edu.au/au/legis/cth/table/"
+      ],
+      "sourceRole": "cross-jurisdiction discovery and comparison index",
+      "provenanceStatus": "requires-record-level-source-attribution",
+      "licenceStatus": "review-required-before-redistribution",
+      "licenceEvidenceUrl": "https://www5.austlii.edu.au/au/legis/cth/table/",
+      "coverageCaveats": [
+        "AustLII states that its legislation databases may lag amendments after the database update.",
+        "The Commonwealth legislation table identifies Commonwealth ownership and reserves rights outside permitted use.",
+        "Aggregator content must not be treated as an official consolidated source."
+      ],
+      "runtimeDecision": "evaluation-only",
+      "nextEvidence": [
+        "obtain written redistribution terms for the intended integration",
+        "prove record-level links to the originating official register",
+        "define freshness and conflict handling against official sources"
+      ]
+    },
+    {
+      "providerId": "nzlii",
+      "name": "New Zealand Legal Information Institute",
+      "jurisdictions": ["nz"],
+      "sourceUrls": [
+        "https://www.nzlii.org/",
+        "https://austlii.community/foswiki/NZResources/NZLIIUserGuide/NZLIIUsagePolicy"
+      ],
+      "sourceRole": "New Zealand legal-information discovery index",
+      "provenanceStatus": "requires-record-level-source-attribution",
+      "licenceStatus": "review-required-before-redistribution",
+      "licenceEvidenceUrl": "https://austlii.community/foswiki/NZResources/NZLIIUserGuide/NZLIIUsagePolicy",
+      "coverageCaveats": [
+        "The usage policy limits copying and reuse to permitted purposes and applicable copyright law.",
+        "Official New Zealand legislation remains the authority for current text and status."
+      ],
+      "runtimeDecision": "evaluation-only",
+      "nextEvidence": [
+        "confirm intended automated access is permitted",
+        "prove record-level links to legislation.govt.nz",
+        "define freshness and missing-record reporting"
+      ]
+    }
+  ],
+  "fixturePolicy": "metadata-only evaluation fixture; no legal text, extracted records, or fabricated coverage claims"
+}

--- a/tests/aggregator-provider-evaluation.test.ts
+++ b/tests/aggregator-provider-evaluation.test.ts
@@ -1,0 +1,50 @@
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+const fixture = JSON.parse(
+  readFileSync(
+    resolve(process.cwd(), 'docs/maintainers/aggregator-provider-evaluation.json'),
+    'utf8'
+  )
+) as {
+  policy: Record<string, boolean>;
+  candidates: Array<{
+    providerId: string;
+    sourceUrls: string[];
+    provenanceStatus: string;
+    licenceStatus: string;
+    runtimeDecision: string;
+    nextEvidence: string[];
+  }>;
+  fixturePolicy: string;
+};
+
+describe('aggregator provider evaluation', () => {
+  it('keeps the evaluation fail-closed and metadata-only', () => {
+    expect(fixture.policy).toMatchObject({
+      officialSourceFirst: true,
+      runtimeEnabled: false,
+      legalRecordsIncluded: false,
+      submissionAllowed: false,
+      attributionRequired: true,
+      licenceReviewRequired: true,
+    });
+    expect(fixture.fixturePolicy).toContain('metadata-only');
+    expect(fixture.fixturePolicy).toContain('no legal text');
+  });
+
+  it('requires HTTPS provenance, licence review, and explicit runtime gating', () => {
+    expect(fixture.candidates.length).toBeGreaterThanOrEqual(2);
+    for (const candidate of fixture.candidates) {
+      expect(candidate.sourceUrls.length).toBeGreaterThan(0);
+      for (const sourceUrl of candidate.sourceUrls) {
+        expect(new URL(sourceUrl).protocol).toBe('https:');
+      }
+      expect(candidate.provenanceStatus).toContain('requires');
+      expect(candidate.licenceStatus).toContain('review-required');
+      expect(candidate.runtimeDecision).toBe('evaluation-only');
+      expect(candidate.nextEvidence.length).toBeGreaterThan(0);
+    }
+  });
+});


### PR DESCRIPTION
## Summary\n- record AustLII and NZLII source, provenance, licence, and freshness constraints\n- keep cross-jurisdiction aggregators evaluation-only with no legal records or runtime route\n- add metadata contract tests and complete the Conductor evaluation phase\n\nCloses #48